### PR TITLE
Develop overlap filters

### DIFF
--- a/hierarchical_peaks.py
+++ b/hierarchical_peaks.py
@@ -357,11 +357,13 @@ class PeakTree:
             node for node in self.subtree(localroot) if len(self.children(node)) == 1
         )
 
-    def filter(self, *, maxsize, localroot=None):
+    def filter(self, *, maxsize=None, localroot=None):
         """Yield subtree nodes filtered by size."""
         # defaults:
         if localroot is None:
             localroot = self.root()
+        if maxsize is None:
+            maxsize = 0.2 * self.size(self.root())
         # The 'maxdeep' algorithm:
         if self.size(localroot) < maxsize:
             yield localroot
@@ -617,11 +619,13 @@ class HyperPeakTree(PeakTree):
             for b in self.R.leaf_nodes():
                 yield a, b
 
-    def filter(self, *, maxsize, localroot=None):
+    def filter(self, *, maxsize=None, localroot=None):
         """Yield grid nodes in given subtree."""
         # defaults:
         if localroot is None:
             localroot = self.root()
+        if maxsize is None:
+            maxsize = 0.2 * max(self.L.size(self.L.root()), self.R.size(self.R.root()))
         ra, rb = localroot
         for a in self.L.filter(maxsize=maxsize, localroot=ra):
             for b in self.R.filter(maxsize=maxsize, localroot=rb):


### PR DESCRIPTION
Close #10

As also discussed in issue #10, the goal is to develop overlap filters, that can pick the innermost items (alternatively the outermost items) out of a set of nested items, see the example plot:

![innout](https://github.com/eivindtostesen/hierarchical_peak_finding/assets/38396753/bc9917c3-603f-4b73-b41a-3a7c0c014a4e)

This PR develops two new recursive tree algorithms, implemented in the `PeakTree` methods `innermost` and `outermost`. These methods are inherited by `HyperPeakTree`.

Previously, we could call

`tree.filter(maxsize=7.5)`

and it would be equivalent to this list comprehension:

`[x for x in tree if tree.size(x) < 7.5 and tree.size(tree.parent(x)) >= 7.5]`.

Now, it can equivalently be generated in two filtering steps:

`tree.outermost(filter(lambda n: tree.size(n) < 7.5, tree))`.

(First, a cutoff on size is applied, and then the outermost filter is applied.)

By "equivalent" is meant that the same items are iterated over, but not in the same order.

It also works in hyper dimensions:

`(tree1 @ tree2).filter(maxsize=7.5)`

is equivalent to

`(tree1 @ tree2).outermost(filter(lambda n: (tree1 @ tree2).size(n) < 7.5, (tree1 @ tree2))`.