### PR TITLE
11 dev errors

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Python module for errors and exceptions.
+
+Created on Thu Mar 30 16:31:58 2023
+
+@author: Eivind Tostesen
+"""
+
+
+class PeakyBlunder(Exception):
+    pass

--- a/utilities.py
+++ b/utilities.py
@@ -2,11 +2,16 @@
 # -*- coding: utf-8 -*-
 """Python module containing tools and utilities.
 
+Requires Python 3.8+
+
 Created on Thu Dec  1 15:48:10 2022
 
 @author: Eivind Tostesen
 
 """
+
+
+from errors import PeakyBlunder
 
 
 # Classes:
@@ -26,8 +31,10 @@ class ChainedAttributes:
         if attrname is None:
             attrname = str.lower(type(self).__name__)
 
-        if hasattr(obj, attrname) or self.parentself is not None:
-            pass
+        if self.parentself is not None:
+            raise PeakyBlunder(f"Attributed as '{self.attrname}'. Call method 'delattr' to break.")
+        elif hasattr(obj, attrname):
+            raise PeakyBlunder(f"The {attrname=} already exists.")
 
         self.attrname = attrname
         setattr(obj, self.attrname, self)


### PR DESCRIPTION
close #11

In utilities.ChainedAttributes, instead of overwriting an existing attribute of a naive object, an errors.PeakyBlunder will now be raised.