### PR TITLE
Improve str

### DIFF
--- a/peaks_in_matplotlib.py
+++ b/peaks_in_matplotlib.py
@@ -157,7 +157,7 @@ class TreeMatPlotLib(ChainedAttributes):
         self.boundary_value = boundary_value
         self.slice_of_x = slice_of_x
         self.slice_of_y = slice_of_y
-        self.level = self.rootself.levels()
+        self.level = dict(self.rootself.levels())
         if not xlim:
             self.xlim = (
                 self.X[self.rootself.root().start],

--- a/strings.py
+++ b/strings.py
@@ -76,3 +76,36 @@ class TreeStrings(ChainedAttributes):
                 string += " => "
             string += f"{full}.\n"
         return string if return_string else print(string)
+
+    def boxdrawing(
+        self,
+        localroot=None,
+        return_string=False,
+        nonlast="├─",
+        last="└─",
+        vert="│ ",
+        spaces="  ",
+        margin="",
+    ):
+        """Print subtree using box drawing characters."""
+        # defaults:
+        if localroot is None:
+            localroot = self.rootself.root()
+
+        indent = [margin]
+        lines = []
+        for node, level in self.rootself.levels(localroot=localroot):
+            if level == 0:
+                # if node is localroot:
+                lines.append(margin + str(node))
+            elif node == self.rootself.children(self.rootself.parent(node))[-1]:
+                # if node is a last child:
+                del indent[level:]
+                lines.append("".join([*indent, last, str(node)]))
+                indent.append(spaces)
+            else:
+                # if node is a non-last child:
+                del indent[level:]
+                lines.append("".join([*indent, nonlast, str(node)]))
+                indent.append(vert)
+        return "\n".join(lines) if return_string else print(*lines, sep="\n")

--- a/strings.py
+++ b/strings.py
@@ -63,7 +63,9 @@ class TreeStrings(ChainedAttributes):
                     )
                 if len(self.rootself.children(self.rootself.parent(node))) > 2:
                     string += (
-                        f" /& {self.rootself.lateral(self.rootself.parent(node))}/"
+                        " /& "
+                        + ", ".join(self.rootself.lateral(self.rootself.parent(node)))
+                        + "/"
                     )
                 string += " => "
             string += f"{full}.\n"

--- a/strings.py
+++ b/strings.py
@@ -36,12 +36,19 @@ class TreeStrings(ChainedAttributes):
             string = f"Tree.from_levels(\n{pprint.pformat(dict(self.rootself.levels()), indent=2, sort_dicts=False)}\n)"
         return string if return_string else print(string)
 
-    def indented_list(self, indent="| ", return_string=False):
+    def indented_list(self, localroot=None, indent="| ", return_string=False):
         """Print tree in indented list notation."""
-        string = "\n".join(
-            [level * indent + str(node) for node, level in self.rootself.levels()]
-        )
-        return string if return_string else print(string)
+        # defaults:
+        if localroot is None:
+            localroot = self.rootself.root()
+        if return_string:
+            return "\n".join(
+                level * indent + str(node)
+                for node, level in self.rootself.levels(localroot=localroot)
+            )
+        else:
+            for node, level in self.rootself.levels(localroot=localroot):
+                print(level * indent + str(node))
 
     def riverflow(self, localroot=None, return_string=False):
         """Print subtree in riverflow notation."""

--- a/strings.py
+++ b/strings.py
@@ -27,20 +27,19 @@ class TreeStrings(ChainedAttributes):
         """Attach a string methods object."""
         super().__init__()
         self.setattr(obj=tree, attrname=attrname)
-        self.level = self.rootself.levels()
 
     def repr(self, return_string=False):
         """Prettyprint a repr that can reconstruct the tree."""
         if hasattr(self.rootself, "L"):
             string = f"HyperTree(\n{self.rootself.L.string.repr(return_string=True)}, \n{self.rootself.R.string.repr(return_string=True)}\n)"
         else:
-            string = f"Tree.from_levels(\n{pprint.pformat(self.level, indent=2, sort_dicts=False)}\n)"
+            string = f"Tree.from_levels(\n{pprint.pformat(dict(self.rootself.levels()), indent=2, sort_dicts=False)}\n)"
         return string if return_string else print(string)
 
     def indented_list(self, indent="| ", return_string=False):
         """Print tree in indented list notation."""
         string = "\n".join(
-            [level * indent + str(node) for node, level in self.level.items()]
+            [level * indent + str(node) for node, level in self.rootself.levels()]
         )
         return string if return_string else print(string)
 

--- a/trees.py
+++ b/trees.py
@@ -176,9 +176,24 @@ class Tree:
         return f"Tree.from_levels({repr(dict(self.levels()))})"
 
     def __str__(self):
-        """Return string with tree in indented list notation."""
-        indent = "| "
-        return "\n".join([level * indent + str(node) for node, level in self.levels()])
+        """Return tree as string using box drawing characters."""
+        indent = [""]
+        lines = []
+        for node, level in self.levels():
+            if level == 0:
+                # if node is root:
+                lines.append(str(node))
+            elif node == self.children(self.parent(node))[-1]:
+                # if node is a last child:
+                del indent[level:]
+                lines.append("".join([*indent, "└─", str(node)]))
+                indent.append("  ")
+            else:
+                # if node is a non-last child:
+                del indent[level:]
+                lines.append("".join([*indent, "├─", str(node)]))
+                indent.append("│ ")
+        return "\n".join(lines)
 
     def as_dict_of_dicts(self):
         """Return data attributes as a dict of dicts."""

--- a/trees.py
+++ b/trees.py
@@ -119,8 +119,8 @@ class Tree:
         return obj
 
     @classmethod
-    def from_levels(cls, levels):
-        """Return new Tree from other tree's levels() output."""
+    def from_levels(cls, levelsdict):
+        """Return new Tree from other tree's levels-dict."""
 
         def leaf_and_core(node):
             children[node] = []
@@ -132,7 +132,7 @@ class Tree:
         children = {}
         obj._core = {}
         obj._full = {}
-        for (A, a), (B, b) in pairwise(levels.items()):
+        for (A, a), (B, b) in pairwise(levelsdict.items()):
             if a == 0:  # first item is the root:
                 obj._parent[A] = None
                 obj._full[A] = A
@@ -173,14 +173,12 @@ class Tree:
 
     def __repr__(self) -> str:
         """Return string that can reconstruct the Tree."""
-        return f"Tree.from_levels({repr(self.levels())})"
+        return f"Tree.from_levels({repr(dict(self.levels()))})"
 
     def __str__(self):
         """Return string with tree in indented list notation."""
         indent = "| "
-        return "\n".join(
-            [level * indent + str(node) for node, level in self.levels().items()]
-        )
+        return "\n".join([level * indent + str(node) for node, level in self.levels()])
 
     def as_dict_of_dicts(self):
         """Return data attributes as a dict of dicts."""
@@ -207,15 +205,14 @@ class Tree:
         self._root = new(self._root)
         return None
 
-    def levels(self):
-        """Return ordered dict of node:level pairs (root is zero level)."""
-        levels = {}
-        for node in self.subtree():
-            if self.is_nonroot(node):
-                levels[node] = 1 + levels[self.parent(node)]
-            else:
-                levels[node] = 0
-        return levels
+    def levels(self, localroot=None, level=0):
+        """Yield ordered sequence of (node, level) tuples (root is zero level)."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        yield (localroot, level)
+        for child in self.children(localroot):
+            yield from self.levels(child, level + 1)
 
     def root(self):
         """Return the root node of the Tree."""


### PR DESCRIPTION
## Goal:

The previous one-line code

https://github.com/eivindtostesen/hierarchical_peak_finding/blob/9f3d220ab4bbc04709e51ce3950ab8abbf0f6b3d/trees.py#L181

prints trees in this style

```
2:18
| 3:8
| | 4:8
| | | 4:7
| 10:15
| | 13:14
| | 11:12
| 16:17
```
which works visually. But it is worth spending a few extra lines to print something like

```
2:18
├─3:8
│ └─4:8
│   └─4:7
├─10:15
│ ├─13:14
│ └─11:12
└─16:17
```
which works better, visually.

## Solution:

- Trees now have string methods to produce the style using a couple of unicode box drawing characters
- Fixed a bug
- Added a localroot parameter here and there
- The one-liner grew into:
https://github.com/eivindtostesen/hierarchical_peak_finding/blob/e88f8334f2d009c3f9e31445929b43bb0b30afa3/trees.py#L182-L196