### PR TITLE
Develop forests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Peakoscope is a python package for hierarchical analysis of peak and valley regions in numeric data.
 
-![peak plot](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.1.0/output.png?raw=true "fig, (peaks.plot.ax, valleys.plot.ax) = plt.subplots(2, 1, sharex=True, figsize=(4, 4));
+![peak plot](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.2.0/output.png?raw=true "fig, (peaks.plot.ax, valleys.plot.ax) = plt.subplots(2, 1, sharex=True, figsize=(4, 4));
 peaks.plot.crowns(peaks.size_filter(maxsize=7))
 peaks.plot.bounding_boxes(peaks.size_filter(maxsize=7))
 valleys.plot.crowns(valleys.size_filter(maxsize=7), facecolor='C9')
@@ -14,17 +14,18 @@ valleys.plot.ax.set_title('Valley regions')
 peaks.plot.ax.plot(X, Y, linewidth=2, color='black')
 valleys.plot.ax.plot(X, Y, linewidth=2, color='black');")
 
-* Peak and valley regions can be nested, for example, when a large peak region contains smaller subpeak regions.
-* Based on a one-pass algorithm that finds all peak regions and orders them into a tree.
-* Classes for peak/valley and tree objects.
-* CLI and optional interfaces to matplotlib, pandas and polars.
+* Peak regions can be nested, for example, when a large peak region contains smaller subpeak regions.
+* A one-pass algorithm that finds all nested regions and orders them into a tree.
+* Trees that can filtered, traversed, partitioned, pruned, grafted and serialized.
+* Optional interfaces: matplotlib, pandas, polars, CLI and object-oriented.
 
 ## Usage examples
 Compute the tree of nested peak regions in a data set:
 ```python
 >>> import peakoscope
 >>> data = [10, 30, 40, 30, 10, 50, 70, 70, 50, 80]
->>> print(peakoscope.tree(data))
+>>> peaktree = peakoscope.tree(data)
+>>> print(peaktree)
 0:10
 ├─5:10
 │ ├─9:10
@@ -32,32 +33,43 @@ Compute the tree of nested peak regions in a data set:
 └─1:4
   └─2:3
 ```
-From the tree, select default peak regions and print their subarrays of data:
+Print the tree minus its root:
 ```python
->>> for peak in peakoscope.tree(data).size_filter():
-...    print(peak.subarray(data))
-... 
-[30, 40, 30]
-[70, 70]
-[80]
+>>> peaktree = peakoscope.tree(data, forest=True)
+>>> print(peaktree - peaktree.roots())
+5:10
+├─9:10
+└─6:8
+1:4
+└─2:3
+```
+Print the leaf nodes (which are local maxima in data) and corresponding slices of data:
+```python
+>>> for leaf in peaktree.leaf_nodes():
+...    print(leaf, leaf.subarray(data))
+...
+9:10 [80]
+6:8 [70, 70]
+2:3 [40]
 ```
 
 ## Documentation
-The github repo contains tutorials and a glossary:
-* [plotting_tutorial.ipynb](https://nbviewer.org/github/eivindtostesen/hierarchical_peak_finding/blob/v1.1.0/plotting_tutorial.ipynb)
-* [dataframes_tutorial.ipynb](https://nbviewer.org/github/eivindtostesen/hierarchical_peak_finding/blob/v1.1.0/dataframes_tutorial.ipynb)
-* [glossary.rst](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.1.0/glossary.rst)
+Demo, tutorials and a glossary:
+* [Streamlit demo](https://github.com/eivindtostesen/peakoscope-demo)
+* [plotting_tutorial.ipynb](https://nbviewer.org/github/eivindtostesen/hierarchical_peak_finding/blob/v1.2.0/plotting_tutorial.ipynb)
+* [dataframes_tutorial.ipynb](https://nbviewer.org/github/eivindtostesen/hierarchical_peak_finding/blob/v1.2.0/dataframes_tutorial.ipynb)
+* [glossary.rst](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.2.0/glossary.rst)
 
 ## Authors
 * Eivind Tøstesen, <contact@tostesen.no>
 
 ## License
-Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under [GPL-3.0-or-later](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.1.0/LICENSE?raw=true "included LICENSE file")
+Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under [GPL-3.0-or-later](https://github.com/eivindtostesen/hierarchical_peak_finding/blob/v1.2.0/LICENSE?raw=true "included LICENSE file")
 
 ## Citation
 Citation can include one or more of:
 
-* Peakoscope v1.1.0
+* Peakoscope v1.2.0
 * Github URL: https://github.com/eivindtostesen/hierarchical_peak_finding
 * PyPI URL: https://pypi.org/project/peakoscope/
 * The open-access article:

--- a/glossary.rst
+++ b/glossary.rst
@@ -23,7 +23,7 @@ argmin
 
 branching node
   A node that has two or more children.
-  Implemented in method ``Tree.branch_nodes()``.
+  Implemented in tree or forest method ``branch_nodes()``.
   See also leaf node and linear node.
 
 cutoff
@@ -38,11 +38,19 @@ extremum
   Maximum of a peak region. Minimum of a valley region.
   See also argext.
 
+forest
+  A forest consists of zero, one or more trees of nested regions.
+  The roots of a forest are the roots of its trees.
+  Each node in a forest has a unique root.
+  Implemented in the classes ``Forest`` and ``HyperForest``,
+  that are containers of nodes, not trees.
+  See also tree.
+
 full node
   The outermost of all nodes having the same argext.
   "Full" as in "full lake".
   A node is full if and only if it is not a main child.
-  Implemented in the methods ``Tree.full()`` and ``Tree.full_nodes()``.
+  Implemented in the tree or forest methods ``full()`` and ``full_nodes()``.
   See also tip node.
 
 ``i:j``
@@ -53,7 +61,7 @@ innermost node
   An innermost node of a subset of nodes is a
   node in the subset that has no descendants in the subset.
   Other nodes in the subset are not nested inside an innermost node.
-  Implemented in method ``Tree.innermost()``.
+  Implemented in tree or forest method ``innermost()``.
   See also outermost node.
 
 ``istop``
@@ -64,39 +72,39 @@ innermost node
 lateral child
   A child node that has a different argext than its parent.
   "Lateral" as in "lateral branch".
-  Implemented in methods ``Tree.lateral()`` and ``Tree.lateral_descendants()``.
+  Implemented in tree or forest methods ``lateral()`` and ``lateral_descendants()``.
   See also main child.
 
 leaf node
   A node that has no children.
-  Implemented in method ``Tree.leaf_nodes()``.
+  Implemented in tree or forest method ``leaf_nodes()``.
   See also linear node and branching node.
 
 level
   Number of steps to the root, in other words, a root node has level 0,
   its children have level 1, grandchildren level 2, etc.
-  Implemented in method ``Tree.levels()``.
+  Implemented in tree or forest method ``levels()``.
 
 linear node
   A node that has one child.
-  Implemented in method ``Tree.linear_nodes()``.
+  Implemented in tree or forest method ``linear_nodes()``.
   See also leaf node and branching node.
 
 local maximum
-  A region containing equal values where all surrounding (``pre`` and ``post``) values
-  are less than the value in the region.
+  A region containing equal values where all surrounding
+  (``pre`` and ``post``) values are less than the value in the region.
   The definition is implemented in the method ``Region.is_local_maximum()``.
   See also peak.
 
 local minimum
-  A region containing equal values where all surrounding (``pre`` and ``post``) values
-  are greater than the value in the region.
+  A region containing equal values where all surrounding
+  (``pre`` and ``post``) values are greater than the value in the region.
   The definition is implemented in the method ``Region.is_local_minimum()``.
   See also valley.
 
 main child
   A child node that has the same argext as its parent.
-  Implemented in methods ``Tree.main_child()`` and ``Tree.main_descendants()``.
+  Implemented in tree or forest methods ``main_child()`` and ``main_descendants()``.
   See also lateral child.
 
 ``max``
@@ -112,14 +120,15 @@ nested region
   ``Region.__lt__()`` and ``Region.__gt__()``.  
 
 node
-  A ``Tree`` node is a ``Scope`` or other hashable object representing a peak or valley.
-  A ``HyperTree`` node is a tuple of nodes.
+  A node in a ``Tree`` or ``Forest`` is a ``Scope`` or other hashable object
+  representing a peak or valley.
+  A node in a ``HyperTree`` or ``HyperForest`` is a tuple of nodes.
 
 outermost node
   An outermost node of a subset of nodes is a
   node in the subset that is not descendant of any node in the subset.
   An outermost node is not nested inside other nodes in the subset.
-  Implemented in method ``Tree.outermost()``.
+  Implemented in tree or forest method ``outermost()``.
   See also innermost node.
 
 parent node
@@ -127,7 +136,8 @@ parent node
 
 path
   Sequence of adjacent nodes in tree.
-  Implemented in methods ``Tree.path()``, ``Tree.root_path()`` and ``Tree.main_path()``. 
+  Implemented in tree or forest methods ``path()``, ``root_path()``
+  and ``main_path()``. 
 
 peak
   A region where all surrounding (``pre`` and ``post``) values
@@ -160,6 +170,7 @@ scope
 size
   The size of region ``r`` is the difference between its maximum and minimum
   or equivalently: ``abs(r.extremum - r.cutoff)``.
+  Implemented in the tree or forest method ``size()``.
 
 ``start``
   The start position of a region.
@@ -171,24 +182,24 @@ size
   See also ``istop``.
 
 subarray
-  A new sequence corresponding to a region.
+  A new sequence (slice) based on a region.
   Implemented in the method ``Region.subarray()``.
 
 subtree
   A node and all its descendants.
-  Implemented in the method ``Tree.subtree()``.
+  Implemented in the tree or forest method ``subtree()``.
 
 tip node
   The innermost of all nodes having the same argext.
   "Tip" as in "fingertip" or "tip of the iceberg".
   A node is a tip if and only if it has no main child.
-  Implemented in the method ``Tree.tip()``.
+  Implemented in the tree or forest method ``tip()``.
   See also full node.
 
 tree
-  A graph of nested peak regions or valley regions.
+  A single-root graph of nested peak regions or valley regions.
   Implemented in the function ``tree()`` and classes ``Tree`` and ``HyperTree``.
-  See also nested region.
+  See also forest.
 
 valley
   A region where all surrounding (``pre`` and ``post``) values

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev6"
+__version__ = "1.2.0.dev7"
 
 
 # Import names:

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev3"
+__version__ = "1.2.0.dev4"
 
 
 # Import names:
@@ -48,17 +48,18 @@ from peakoscope.data import example_1, example_2
 
 
 # Wrapper function:
-def tree(data, *, valleys=False):
-    """Find all peaks (or valleys) in data and return their Tree."""
+def tree(data, *, valleys=False, forest=False):
+    """Return a tree of all peaks (or valleys) in data."""
+    treeclass = Forest if forest else Tree
     if valleys:
-        return Tree.from_valleys(
+        return treeclass.from_valleys(
             map(
                 lambda t: Scope.from_attrs(Scope6(*t), data),
                 find_valleys(data),
             )
         )
     else:
-        return Tree.from_peaks(
+        return treeclass.from_peaks(
             map(
                 lambda t: Scope.from_attrs(Scope6(*t), data),
                 find_peaks(data),

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev7"
+__version__ = "1.2.0.dev8"
 
 
 # Import names:
@@ -51,11 +51,10 @@ from peakoscope.data import example_1, example_2
 def tree(data, *, valleys=False, forest=False):
     """Return a tree of all peaks (or valleys) in data."""
     treeclass = Forest if forest else Tree
+    _pipe1 = find_peaks(data, reverse=valleys)
+    _pipe2 = map(lambda t: Scope.from_attrs(Scope6(*t), data), _pipe1)
     return treeclass(
-        map(
-            lambda t: Scope.from_attrs(Scope6(*t), data),
-            find_peaks(data, reverse=valleys),
-        ),
+        _pipe2,
         are_valleys=valleys,
         presorted=True,
     )

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,13 +35,13 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.1.0"
+__version__ = "1.2.0.dev1"
 
 
 # Import names:
 from peakoscope.errors import PeakyBlunder
 from peakoscope.utilities import ChainedAttributes
-from peakoscope.trees import tree_from_peaks, Tree, HyperTree
+from peakoscope.trees import tree_from_peaks, forest_from_peaks, Tree, HyperTree
 from peakoscope.peaks import find_peaks, find_valleys, Scope6, Region, Scope
 from peakoscope.formats import TreeStrings
 from peakoscope.data import example_1, example_2

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,13 +35,13 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev1"
+__version__ = "1.2.0.dev2"
 
 
 # Import names:
 from peakoscope.errors import PeakyBlunder
 from peakoscope.utilities import ChainedAttributes
-from peakoscope.trees import tree_from_peaks, forest_from_peaks, Tree, HyperTree
+from peakoscope.trees import tree_from_peaks, forest_from_peaks, Tree, HyperTree, Forest
 from peakoscope.peaks import find_peaks, find_valleys, Scope6, Region, Scope
 from peakoscope.formats import TreeStrings
 from peakoscope.data import example_1, example_2

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev5"
+__version__ = "1.2.0.dev6"
 
 
 # Import names:
@@ -51,17 +51,11 @@ from peakoscope.data import example_1, example_2
 def tree(data, *, valleys=False, forest=False):
     """Return a tree of all peaks (or valleys) in data."""
     treeclass = Forest if forest else Tree
-    if valleys:
-        return treeclass.from_valleys(
-            map(
-                lambda t: Scope.from_attrs(Scope6(*t), data),
-                find_valleys(data),
-            )
-        )
-    else:
-        return treeclass.from_peaks(
-            map(
-                lambda t: Scope.from_attrs(Scope6(*t), data),
-                find_peaks(data),
-            )
-        )
+    return treeclass(
+        map(
+            lambda t: Scope.from_attrs(Scope6(*t), data),
+            find_peaks(data, reverse=valleys),
+        ),
+        are_valleys=valleys,
+        presorted=True,
+    )

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev8"
+__version__ = "1.2.0.dev9"
 
 
 # Import names:

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev10"
+__version__ = "1.2.0.dev11"
 
 
 # Import names:

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,13 +35,20 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev9"
+__version__ = "1.2.0.dev10"
 
 
 # Import names:
 from peakoscope.errors import PeakyBlunder
 from peakoscope.utilities import ChainedAttributes
-from peakoscope.trees import tree_from_peaks, forest_from_peaks, Tree, HyperTree, Forest
+from peakoscope.trees import (
+    tree_from_peaks,
+    forest_from_peaks,
+    Tree,
+    HyperTree,
+    Forest,
+    HyperForest,
+)
 from peakoscope.peaks import find_peaks, find_valleys, Scope6, Region, Scope
 from peakoscope.formats import TreeStrings
 from peakoscope.data import example_1, example_2

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev2"
+__version__ = "1.2.0.dev3"
 
 
 # Import names:

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -13,7 +13,8 @@ Usage examples:
 Compute the tree of nested peak regions in a data set:
 
 >>> data = [10, 30, 40, 30, 10, 50, 70, 70, 50, 80]
->>> print(tree(data))
+>>> peaktree = tree(data)
+>>> print(peaktree)
 0:10
 ├─5:10
 │ ├─9:10
@@ -21,21 +22,31 @@ Compute the tree of nested peak regions in a data set:
 └─1:4
   └─2:3
 
-From the tree, select default peak regions and print their subarrays of data:
+Print the tree minus its root:
 
->>> for peak in tree(data).size_filter():
-...    print(peak.subarray(data))
+>>> peaktree = tree(data, forest=True)
+>>> print(peaktree - peaktree.roots())
+5:10
+├─9:10
+└─6:8
+1:4
+└─2:3
+
+Print the leaf nodes (which are local maxima in data) and corresponding slices of data:
+
+>>> for leaf in peaktree.leaf_nodes():
+...    print(leaf, leaf.subarray(data))
 ...
-[30, 40, 30]
-[70, 70]
-[80]
+9:10 [80]
+6:8 [70, 70]
+2:3 [40]
 
 Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.0-or-later.
 
 """
 
 
-__version__ = "1.2.0.dev11"
+__version__ = "1.2.0.dev12"
 
 
 # Import names:
@@ -56,7 +67,7 @@ from peakoscope.data import example_1, example_2
 
 # Wrapper function:
 def tree(data, *, valleys=False, forest=False):
-    """Return a tree of all peaks (or valleys) in data."""
+    """Return a single tree of all peaks (or valleys) in data."""
     treeclass = Forest if forest else Tree
     _pipe1 = find_peaks(data, reverse=valleys)
     _pipe2 = map(lambda t: Scope.from_attrs(Scope6(*t), data), _pipe1)

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -46,7 +46,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev12"
+__version__ = "1.2.0"
 
 
 # Import names:

--- a/peakoscope/__init__.py
+++ b/peakoscope/__init__.py
@@ -35,7 +35,7 @@ Copyright (C) 2021-2025 Eivind Tøstesen. This software is licensed under GPL-3.
 """
 
 
-__version__ = "1.2.0.dev4"
+__version__ = "1.2.0.dev5"
 
 
 # Import names:

--- a/peakoscope/peaks.py
+++ b/peakoscope/peaks.py
@@ -44,7 +44,7 @@ Scope6(start=0, istop=9, argext=9, argcut=0, extremum=80, cutoff=10)
 
 from collections import namedtuple
 from operator import lt, gt, le, ge
-from peakoscope.utilities import pairwise
+from peakoscope.utilities import pairwise, sample_iterator
 from peakoscope.errors import PeakyBlunder
 
 
@@ -53,32 +53,37 @@ from peakoscope.errors import PeakyBlunder
 
 def find_peaks(values, reverse=False):
     """Yield peak regions as tuples: (start, istop, argext, argcut, extremum, cutoff)."""
-    if not reverse:
-        lessthan, greaterthan, greater_equal = lt, gt, ge
-    else:
-        lessthan, greaterthan, greater_equal = gt, lt, le
-    regions = []
-    for i, (y1, y2) in enumerate(pairwise(values)):
-        if i == 0:  # first data point:
-            regions.append([i, None, i, i, y1, y1])
-        if greaterthan(y2, y1):  # if uphill:
-            for r in reversed(regions):
-                if greater_equal(r[4], y2):
-                    break
-                r[2], r[4] = i + 1, y2  # update argext and extremum value
-            regions.append([i + 1, None, i + 1, i + 1, y2, y2])
-        elif y2 == y1:
-            pass  # region already created
-        elif lessthan(y2, y1):  # if downhill:
-            while regions and lessthan(y2, regions[-1][5]):
-                popped = regions.pop()
-                popped[1] = i  # update istop value
-                yield tuple(popped)
-            if not (regions and y2 == regions[-1][5]):
-                regions.append([popped[0], None, popped[2], i + 1, popped[4], y2])
-    for r in reversed(regions):
-        r[1] = i + 1  # use last i value
-        yield tuple(r)
+    sample, values = sample_iterator(values)
+    if len(sample) == 1:
+        y = sample.pop()
+        yield (0, 0, 0, 0, y, y)
+    elif len(sample) > 1:
+        if not reverse:
+            lessthan, greaterthan, greater_equal = lt, gt, ge
+        else:
+            lessthan, greaterthan, greater_equal = gt, lt, le
+        regions = []
+        for i, (y1, y2) in enumerate(pairwise(values)):
+            if i == 0:  # first data point:
+                regions.append([i, None, i, i, y1, y1])
+            if greaterthan(y2, y1):  # if uphill:
+                for r in reversed(regions):
+                    if greater_equal(r[4], y2):
+                        break
+                    r[2], r[4] = i + 1, y2  # update argext and extremum value
+                regions.append([i + 1, None, i + 1, i + 1, y2, y2])
+            elif y2 == y1:
+                pass  # region already created
+            elif lessthan(y2, y1):  # if downhill:
+                while regions and lessthan(y2, regions[-1][5]):
+                    popped = regions.pop()
+                    popped[1] = i  # update istop value
+                    yield tuple(popped)
+                if not (regions and y2 == regions[-1][5]):
+                    regions.append([popped[0], None, popped[2], i + 1, popped[4], y2])
+        for r in reversed(regions):
+            r[1] = i + 1  # use last i value
+            yield tuple(r)
 
 
 def find_valleys(values):

--- a/peakoscope/testing.py
+++ b/peakoscope/testing.py
@@ -193,7 +193,7 @@ def assert_size_filter_equals_definition(tree, fractions=None):
     """
     if fractions is None:
         fractions = (-0.1, 0.0, 0.2, 0.6, 2.0)
-    rootsize = max(tree.size(root) for root in tree.roots())
+    rootsize = max((tree.size(root) for root in tree.roots()), default=0)
     for maxsize in (fraction * rootsize for fraction in fractions):
         assert set(tree.size_filter(maxsize=maxsize)) == set(
             x
@@ -207,7 +207,7 @@ def assert_size_filter_equals_outermost_of_below_maxsize(tree, fractions=None):
     """Assert size_filter produces the outermost of all nodes below maxsize."""
     if fractions is None:
         fractions = (-0.1, 0.0, 0.2, 0.6, 2.0)
-    rootsize = max(tree.size(root) for root in tree.roots())
+    rootsize = max((tree.size(root) for root in tree.roots()), default=0)
     for maxsize in (fraction * rootsize for fraction in fractions):
         assert set(tree.size_filter(maxsize=maxsize)) == (
             set(tree.outermost(x for x in tree if tree.size(x) < maxsize))

--- a/peakoscope/testing.py
+++ b/peakoscope/testing.py
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Python module for testing.
 
-Collection of assertion functions for use in testing.
+A collection of assertion functions for use in testing.
 
 Two of the functions assert equality between objects.
 
 The other 19 functions assert expected tree properties.
-Input to each of these is either a Tree, HyperTree
-or Forest object.
+Input to each of these is of type Tree, HyperTree
+Forest or HyperForest.
 
 Usage examples:
 ---------------
@@ -90,7 +90,7 @@ def assert_root_is_outermost_and_leafs_are_innermost(tree):
 
 
 def assert_tree_consists_of_children_and_root(tree):
-    """Assert all nodes are children or root."""
+    """Assert all nodes are children or roots."""
     assert set(tree) == (
         set(chain.from_iterable(tree.children(x) for x in tree)) | set(tree.roots())
     )
@@ -179,7 +179,7 @@ def assert_parent_size_is_strictly_greater(tree):
 
 
 def assert_if_local_extremum_then_leaf(tree):
-    """Assert zero-size nodes are included in leaf nodes."""
+    """Assert size zero implies leaf node."""
     assert set(x for x in tree if tree.size(x) == 0) <= set(tree.leaf_nodes())
 
 

--- a/peakoscope/testing.py
+++ b/peakoscope/testing.py
@@ -8,8 +8,10 @@
 Collection of assertion functions for use in testing.
 
 Two of the functions assert equality between objects.
+
 The other 19 functions assert expected tree properties.
-Input to the each of these is either a Tree or a HyperTree object.
+Input to each of these is either a Tree, HyperTree
+or Forest object.
 
 Usage examples:
 ---------------
@@ -55,11 +57,11 @@ def assert_iteration_produces_members(tree):
 
 
 def assert_leafs_have_no_children_and_root_has_no_parent(tree):
-    """Assert leaf nodes have no children, root has no parent."""
+    """Assert leaf nodes have no children, roots have no parent."""
     assert all(tree.has_children(x) is False for x in tree.leaf_nodes())
     assert all(tree.children(x) == () for x in tree.leaf_nodes())
-    assert tree.is_nonroot(tree.root()) is False
-    assert tree.parent(tree.root()) is None
+    assert all(tree.is_nonroot(root) is False for root in tree.roots())
+    assert all(tree.parent(root) is None for root in tree.roots())
 
 
 def assert_parent_and_children_are_inverse_of_each_other(tree):
@@ -79,8 +81,8 @@ def assert_level_is_length_of_root_path(tree):
 
 
 def assert_root_is_outermost_and_leafs_are_innermost(tree):
-    """Assert root is outermost and leaf nodes are innermost."""
-    assert {tree.root()} == set(tree.outermost(tree))
+    """Assert roots are outermost and leaf nodes are innermost."""
+    assert set(tree.roots()) == set(tree.outermost(tree))
     assert set(tree.leaf_nodes()) == set(tree.innermost(tree))
 
 
@@ -90,7 +92,7 @@ def assert_root_is_outermost_and_leafs_are_innermost(tree):
 def assert_tree_consists_of_children_and_root(tree):
     """Assert all nodes are children or root."""
     assert set(tree) == (
-        set(chain.from_iterable(tree.children(x) for x in tree)) | {tree.root()}
+        set(chain.from_iterable(tree.children(x) for x in tree)) | set(tree.roots())
     )
 
 
@@ -114,8 +116,8 @@ def assert_tree_consists_of_full_nodes_and_main_descendants(tree):
 
 
 def assert_full_nodes_consists_of_lateral_descendants_plus_root(tree):
-    """Assert all full nodes are lateral descendants or root."""
-    assert set(tree.full_nodes()) == set(tree.lateral_descendants()) | {tree.root()}
+    """Assert all full nodes are lateral descendants or roots."""
+    assert set(tree.full_nodes()) == set(tree.lateral_descendants()) | set(tree.roots())
 
 
 def assert_children_consist_of_main_child_plus_lateral_children(tree):
@@ -158,9 +160,9 @@ def assert_main_path_shares_tip_and_full(tree):
 
 
 def assert_root_is_full_and_leafs_are_tips(tree):
-    """Assert leaf nodes are tip nodes and root is a full node."""
+    """Assert leaf nodes are tip nodes and roots are full nodes."""
     assert all(tree.tip(x) == x for x in tree.leaf_nodes())
-    assert tree.full(tree.root()) == tree.root()
+    assert all(tree.full(root) == root for root in tree.roots())
 
 
 # node size assertions:
@@ -191,13 +193,13 @@ def assert_size_filter_equals_definition(tree, fractions=None):
     """
     if fractions is None:
         fractions = (-0.1, 0.0, 0.2, 0.6, 2.0)
-    rootsize = tree.size(tree.root())
+    rootsize = max(tree.size(root) for root in tree.roots())
     for maxsize in (fraction * rootsize for fraction in fractions):
         assert set(tree.size_filter(maxsize=maxsize)) == set(
             x
             for x in tree
             if tree.size(x) < maxsize
-            and (x == tree.root() or tree.size(tree.parent(x)) >= maxsize)
+            and (x in tree.roots() or tree.size(tree.parent(x)) >= maxsize)
         )
 
 
@@ -205,7 +207,7 @@ def assert_size_filter_equals_outermost_of_below_maxsize(tree, fractions=None):
     """Assert size_filter produces the outermost of all nodes below maxsize."""
     if fractions is None:
         fractions = (-0.1, 0.0, 0.2, 0.6, 2.0)
-    rootsize = tree.size(tree.root())
+    rootsize = max(tree.size(root) for root in tree.roots())
     for maxsize in (fraction * rootsize for fraction in fractions):
         assert set(tree.size_filter(maxsize=maxsize)) == (
             set(tree.outermost(x for x in tree if tree.size(x) < maxsize))

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -607,7 +607,7 @@ class Forest:
 
     # dunder methods:
 
-    def __init__(self, peaks, *, are_valleys=False, presorted=False):
+    def __init__(self, peaks=(), *, are_valleys=False, presorted=False):
         """Initialize Forest from iterable of peak (or valley) regions."""
         self.are_valleys = are_valleys
         self._roots, self._children, self._tip = forest_from_peaks(

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -1121,3 +1121,187 @@ class HyperTree(Tree):
     def _find_full(self):
         """Return that it is NotImplemented."""
         return NotImplemented
+
+
+class HyperForest(Forest):
+    """Tree of higher-dimensional regions.
+
+    A HyperTree represents the hierarchical nesting of peak regions
+    or valley regions in more dimensions, such as a mountain landscape
+    with height z as a function of x and y.
+
+    A HyperTree assumes dimensional decoupling, i.e. the landscape is a
+    sum z(x,y) = f(x) + g(y) or a product z(x,y) = f(x) * g(y).
+
+    A HyperTree is constructed as a pair of trees that are
+    of type Tree or HyperTree.
+
+    A HyperTree is a kind of product tree, but it is not the Cartesian
+    product.
+
+    Notes
+    -----
+    Background literature for the HyperTree class is
+    the subsection titled "2D peaks" in the article [1]_.
+
+    References
+    ----------
+    .. [1] Tostesen, E. "A stitch in time: Efficient computation of
+       genomic DNA melting bubbles." Algorithms for Molecular
+       Biology 3, 10 (2008).
+       Open access: https://doi.org/10.1186/1748-7188-3-10
+    """
+
+    def __init__(self, left_tree, right_tree):
+        self.L = left_tree
+        self.R = right_tree
+
+    def __contains__(self, pair):
+        """Return True if the input is a node in the HyperTree."""
+        a, b = pair
+        # test if (a, b) is 'parent-above':
+        return (
+            a == self.L.root() or self.L.size(self.L.parent(a)) > self.R.size(b)
+        ) and (b == self.R.root() or self.R.size(self.R.parent(b)) > self.L.size(a))
+
+    def __iter__(self):
+        """Iterate over nodes in the HyperTree."""
+        yield from self.subtree()
+
+    def __len__(self):
+        """Return number of nodes in the HyperTree."""
+        return len(list(self.__iter__()))
+
+    def __repr__(self) -> str:
+        """Return string that can reconstruct the HyperTree."""
+        return f"HyperTree({repr(self.L)}, {repr(self.R)})"
+
+    def root(self):
+        """Return the root node of the HyperTree."""
+        return (self.L.root(), self.R.root())
+
+    def is_nonroot(self, node):
+        """Return True if given node has a parent."""
+        a, b = node
+        return self.L.is_nonroot(a) or self.R.is_nonroot(b)
+
+    def tip(self, node):
+        """Return the given node's tip node."""
+        a, b = node
+        return (self.L.tip(a), self.R.tip(b))
+
+    def has_children(self, node):
+        """Return True if given node has children."""
+        a, b = node
+        return self.L.has_children(a) or self.R.has_children(b)
+
+    def size(self, node):
+        """Return the given node's size."""
+        a, b = node
+        return max(self.L.size(a), self.R.size(b))
+
+    def parent(self, node):
+        """Return the given node's parent or None."""
+        a, b = node
+        if self.L.is_nonroot(a) and self.R.is_nonroot(b):
+            pa, pb = self.L.parent(a), self.R.parent(b)
+            if self.L.size(pa) > self.R.size(pb):
+                return (a, pb)
+            elif self.L.size(pa) < self.R.size(pb):
+                return (pa, b)
+            elif self.L.size(pa) == self.R.size(pb):
+                return (pa, pb)
+        elif not self.L.is_nonroot(a) and not self.R.is_nonroot(b):
+            return None
+        elif self.L.is_nonroot(a):
+            # then b is root
+            return (self.L.parent(a), b)
+        else:
+            # then a is root and b nonroot
+            return (a, self.R.parent(b))
+
+    def children(self, node):
+        """Return the given node's children."""
+        a, b = node
+        if not self.has_children(node):
+            return ()
+        elif self.L.size(a) > self.R.size(b):
+            return tuple((ca, b) for ca in self.L.children(a))
+        elif self.L.size(a) < self.R.size(b):
+            return tuple((a, cb) for cb in self.R.children(b))
+        elif self.L.size(a) == self.R.size(b):
+            return tuple(
+                (ca, cb) for ca in self.L.children(a) for cb in self.R.children(b)
+            )
+
+    def main_child(self, node):
+        """Return the main child (the child that has the same tip)."""
+        a, b = node
+        if not self.has_children(node):
+            return None
+        elif self.L.size(a) > self.R.size(b):
+            return (self.L.main_child(a), b)
+        elif self.L.size(a) < self.R.size(b):
+            return (a, self.R.main_child(b))
+        elif self.L.size(a) == self.R.size(b):
+            return (self.L.main_child(a), self.R.main_child(b))
+
+    def full(self, node):
+        """Return the largest node with same tip as given node."""
+        climber = node
+        while self.is_nonroot(climber) and self.tip(climber) == self.tip(
+            nextstep := self.parent(climber)
+        ):
+            climber = nextstep
+        return climber
+
+    def _index(self, node):
+        """Return a tuple of (nested) indices for given node."""
+        a, b = node
+        return self.L._index(a), self.R._index(b)
+
+    def leaf_nodes(self, localroot=None):
+        """Yield leaf nodes."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        ra, rb = localroot
+        for a in self.L.leaf_nodes(localroot=ra):
+            for b in self.R.leaf_nodes(localroot=rb):
+                yield a, b
+
+    def size_filter(self, localroot=None, *, maxsize=None):
+        """Yield grid nodes in given subtree."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        if maxsize is None:
+            maxsize = 0.2 * max(self.L.size(self.L.root()), self.R.size(self.R.root()))
+        ra, rb = localroot
+        for a in self.L.size_filter(maxsize=maxsize, localroot=ra):
+            for b in self.R.size_filter(maxsize=maxsize, localroot=rb):
+                yield a, b
+
+    def from_peaks(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def from_valleys(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def from_levels(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def as_dict_of_dicts(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def set_nodes(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def _find_full(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -10,8 +10,8 @@ for building trees that represent the hierarchical nesting
 of regions and subregions containing peaks or valleys
 in numeric one-dimensional or higher-dimensional data.
 
-The tree classes provide methods for
-searching, sorting and selecting regions.
+Tree and forest classes provide methods for filtering,
+traversing, partitioning, pruning, grafting and serializing.
 
 """
 
@@ -104,7 +104,7 @@ def forest_from_peaks(
 
 
 class Tree:
-    """Tree of regions in univariate data.
+    """Tree of nested regions.
 
     A Tree represents the hierarchical nesting of
     peak or valley regions in 1D data such as a sequence of numbers,
@@ -479,7 +479,7 @@ class Tree:
 
 
 class Forest:
-    """Trees of regions in univariate data.
+    """Trees of nested regions.
 
     A Forest represents the hierarchical nesting of
     peak or valley regions in 1D data such as a sequence of numbers,
@@ -663,25 +663,25 @@ class Forest:
         return HyperForest(self, other)
 
     def __sub__(self, other):
-        """Return new Forest of nodes in self not other (difference)."""
+        """Return new Forest from nodes in difference: set(self) - set(other)."""
         return Forest(
             set(self) - set(other), are_valleys=self.are_valleys, presorted=False
         )
 
     def __and__(self, other):
-        """Return new Forest of nodes in self and other (intersection)."""
+        """Return new Forest from nodes in intersection: set(self) & set(other)."""
         return Forest(
             set(self) & set(other), are_valleys=self.are_valleys, presorted=False
         )
 
     def __or__(self, other):
-        """Return new Forest of nodes in self or other (union)."""
+        """Return new Forest from nodes in union: set(self) | set(other)."""
         return Forest(
             set(self) | set(other), are_valleys=self.are_valleys, presorted=False
         )
 
     def __xor__(self, other):
-        """Return new Forest of nodes in either self or other (symmetric difference)."""
+        """Return new Forest from nodes in symmetric difference: set(self) ^ set(other)."""
         return Forest(
             set(self) ^ set(other), are_valleys=self.are_valleys, presorted=False
         )
@@ -778,7 +778,7 @@ class Forest:
     # generator methods (yielding nodes):
 
     def path(self, start, istop, step):
-        """Yield nodes on a path in the tree."""
+        """Yield nodes on a path in a tree."""
         climber = start
         yield climber
         while climber != istop:

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -461,6 +461,360 @@ class Tree:
         }
 
 
+class Forest:
+    """Tree of regions in univariate data.
+
+    A Tree represents the hierarchical nesting of
+    peak or valley regions in 1D data such as a sequence of numbers,
+    a time series, a function y(x) or other univariate data.
+
+    A Tree is initialized with an iterable of regions
+    that have start, istop, cutoff, extremum. The regions
+    must be unique hashable objects to be used as dictionary keys.
+
+    Notes
+    -----
+    Background literature for the Tree class is
+    the subsection titled "1D peaks" in the article [1]_.
+
+    References
+    ----------
+    .. [1] Tostesen, E. "A stitch in time: Efficient computation of
+       genomic DNA melting bubbles." Algorithms for Molecular
+       Biology 3, 10 (2008).
+       Open access: https://doi.org/10.1186/1748-7188-3-10
+    """
+
+    @classmethod
+    def from_peaks(cls, peaks, **kwargs):
+        """Return new Tree from iterable of peak regions."""
+        obj = cls.__new__(cls)
+        obj._parent, obj._root, obj._children, obj._tip = tree_from_peaks(
+            peaks, **kwargs
+        )
+        obj._find_full()
+        return obj
+
+    @classmethod
+    def from_valleys(cls, valleys, **kwargs):
+        """Return new Tree from iterable of valley regions."""
+        obj = cls.__new__(cls)
+        obj._parent, obj._root, obj._children, obj._tip = tree_from_peaks(
+            valleys, reverse=True, **kwargs
+        )
+        obj._find_full()
+        return obj
+
+    @classmethod
+    def from_levels(cls, levelsdict, /):
+        """Return new Tree from other tree's levels-dict."""
+
+        def leaf_and_tip(node):
+            children[node] = []
+            for n in obj.path(node, obj._full[node], obj.parent):
+                obj._tip[n] = node
+
+        obj = cls.__new__(cls)
+        obj._parent = {}
+        children = {}
+        obj._tip = {}
+        obj._full = {}
+        for (A, a), (B, b) in pairwise(levelsdict.items()):
+            if a == 0:  # first item is the root:
+                obj._parent[A] = None
+                obj._full[A] = A
+                obj._root = A
+                stack = [A]
+            if b == a + 1:  # a subtree grows:
+                obj._full[B] = obj._full[A]
+                children[stack[-1]] = [B]  # B is the main child (of A)
+            else:  # (then a >= b) a subtree finishes:
+                del stack[b:]  # pop a slice
+                obj._full[B] = B
+                children[stack[-1]].append(B)  # B is a lateral child
+                leaf_and_tip(A)  # A is a leaf and tip
+            obj._parent[B] = stack[-1]
+            stack.append(B)
+        leaf_and_tip(B)  # the last B is a leaf and tip
+        obj._children = {p: tuple(c) for p, c in children.items()}
+        return obj
+
+    def __init__(self, data):
+        pass  # TODO
+
+    def __contains__(self, node):
+        """Return True if the input is a node in the Tree."""
+        return node in self._full
+
+    def __iter__(self):
+        """Iterate over nodes in the Tree."""
+        return iter(self._full)
+
+    def __len__(self):
+        """Return number of nodes in the Tree."""
+        return len(self._full)
+
+    def __matmul__(self, other):
+        """Return product self @ other (other is a Tree or HyperTree)."""
+        return HyperTree(self, other)
+
+    def __repr__(self) -> str:
+        """Return string that can reconstruct the Tree."""
+        return f"Tree.from_levels({repr(dict(self.levels()))})"
+
+    def __str__(self):
+        """Return tree as string using box drawing characters."""
+        indent = [""]
+        lines = []
+        for node, level in self.levels():
+            if level == 0:
+                # if node is root:
+                lines.append(str(node))
+            elif node == self.children(self.parent(node))[-1]:
+                # if node is a last child:
+                del indent[level:]
+                lines.append("".join([*indent, "└─", str(node)]))
+                indent.append("  ")
+            else:
+                # if node is a non-last child:
+                del indent[level:]
+                lines.append("".join([*indent, "├─", str(node)]))
+                indent.append("│ ")
+        return "\n".join(lines)
+
+    def as_dict_of_dicts(self):
+        """Return data attributes as a dict of dicts."""
+        return {
+            "_parent": self._parent,
+            "_children": self._children,
+            "_tip": self._tip,
+            "_full": self._full,
+            "_root": self._root,
+        }
+
+    def set_nodes(self, changes={}):
+        """Replace Tree nodes by using given mapping."""
+
+        def new(node):
+            return changes[node] if node in changes else node
+
+        self._tip = dict((new(x), new(y)) for (x, y) in self._tip.items())
+        self._full = dict((new(x), new(y)) for (x, y) in self._full.items())
+        self._parent = dict((new(x), new(y)) for (x, y) in self._parent.items())
+        self._children = dict(
+            (new(x), tuple(new(z) for z in y)) for (x, y) in self._children.items()
+        )
+        self._root = new(self._root)
+        return None
+
+    def levels(self, localroot=None, level=0):
+        """Yield ordered sequence of (node, level) tuples (root is zero level)."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        yield (localroot, level)
+        for child in self.children(localroot):
+            yield from self.levels(child, level + 1)
+
+    def root(self):
+        """Return the root node of the Tree."""
+        return self._root
+
+    def is_nonroot(self, node):
+        """Return True if the given node has a parent."""
+        return node != self._root
+
+    def tip(self, node):
+        """Return the smallest region with same argext as the given node."""
+        return self._tip[node]
+
+    def has_children(self, node):
+        """Return True if the given node has sub regions."""
+        return node != self._tip[node]
+
+    def size(self, node):
+        """Return vertical size of given node (max minus min)."""
+        return abs(node.extremum - node.cutoff)
+
+    def parent(self, node):
+        """Return the parent (containing region) or None."""
+        return self._parent[node]
+
+    def children(self, node):
+        """Return ordered tuple of children of given node."""
+        return self._children[node]
+
+    def main_child(self, node):
+        """Return child of given node with same argext, or None."""
+        if self.has_children(node):
+            return self.children(node)[0]
+        else:
+            return None
+
+    def lateral(self, node):
+        """Return ordered tuple of the given node's lateral children."""
+        return self.children(node)[1:]
+
+    def full(self, node):
+        """Return the largest region with same argext as the given node."""
+        return self._full[node]
+
+    def _index(self, node):
+        """Return the zero-based index of the given node."""
+        # accessing the preserved insertion order:
+        return list(self._full).index(node)
+
+    # public recursive algorithms:
+
+    def path(self, start, istop, step):
+        """Yield nodes on a path in the tree."""
+        climber = start
+        yield climber
+        while climber != istop:
+            climber = step(climber)
+            yield climber
+
+    def root_path(self, node):
+        """Yield nodes on the parent path from given node to its root."""
+        yield from self.path(node, self.root(), self.parent)
+
+    def main_path(self, node):
+        """Yield nodes on the main_child path from given node to its tip."""
+        yield from self.path(node, self.tip(node), self.main_child)
+
+    def subtree(self, localroot=None):
+        """Yield all nodes in the given subtree."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        yield localroot
+        for child in self.children(localroot):
+            yield from self.subtree(child)
+
+    def main_descendants(self, localroot=None):
+        """Yield main child nodes in the given subtree."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        if self.has_children(localroot):
+            yield self.main_child(localroot)
+            for child in self.children(localroot):
+                yield from self.main_descendants(child)
+
+    def lateral_descendants(self, localroot=None):
+        """Yield lateral child nodes in the given subtree."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        if self.has_children(localroot):
+            yield from self.lateral(localroot)
+            for child in self.children(localroot):
+                yield from self.lateral_descendants(child)
+
+    def full_nodes(self, localroot=None):
+        """Yield full nodes in the given subtree."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        if localroot == self.full(localroot):
+            yield localroot
+        yield from self.lateral_descendants(localroot)
+
+    def leaf_nodes(self, localroot=None):
+        """Yield subtree nodes that have no children."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        return (
+            node for node in self.subtree(localroot) if len(self.children(node)) == 0
+        )
+
+    def branch_nodes(self, localroot=None):
+        """Yield subtree nodes that have two or more children."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        return (
+            node for node in self.subtree(localroot) if len(self.children(node)) > 1
+        )
+
+    def linear_nodes(self, localroot=None):
+        """Yield subtree nodes that have one child."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        return (
+            node for node in self.subtree(localroot) if len(self.children(node)) == 1
+        )
+
+    def size_filter(self, localroot=None, *, maxsize=None):
+        """Yield subtree nodes filtered by size."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        if maxsize is None:
+            maxsize = 0.2 * self.size(self.root())
+        # The 'MAXDEEP algorithm' in reverse:
+        for climber in self.main_path(localroot):
+            if self.size(climber) >= maxsize:
+                for child in self.lateral(climber):
+                    yield from self.size_filter(maxsize=maxsize, localroot=child)
+            elif climber == self.root() or self.size(self.parent(climber)) >= maxsize:
+                yield climber
+                break
+
+    def innermost(self, nodes, localroot=None):
+        """Yield innermost nodes of the given nodes."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        filter = list(nodes)
+        countdown = {n: len(self.children(n)) for n in self.subtree(localroot)}
+
+        # Recursive "bottom-up" search via parents:
+        def _yield_or_propagate(node):
+            if node in filter:
+                yield node
+            elif node != localroot:
+                parent = self.parent(node)
+                countdown[parent] -= 1
+                if countdown[parent] == 0:
+                    yield from _yield_or_propagate(parent)
+
+        for node in self.leaf_nodes(localroot):
+            yield from _yield_or_propagate(node)
+
+    def outermost(self, nodes, localroot=None):
+        """Yield outermost nodes of the given nodes."""
+        # defaults:
+        if localroot is None:
+            localroot = self.root()
+        filter = list(nodes)
+
+        # Recursive "top-down" search via children:
+        def _yield_or_branch(node):
+            if node in filter:
+                yield node
+            elif self.has_children(node):
+                for child in self.children(node):
+                    yield from _yield_or_branch(child)
+
+        yield from _yield_or_branch(localroot)
+
+    # Initialization algorithms:
+
+    def _find_full(self):
+        """Compute attribute: self._full."""
+
+        def fullnodes():
+            yield self.root()
+            yield from self.lateral_descendants()
+
+        self._full = {
+            node: full for full in fullnodes() for node in self.main_path(full)
+        }
+
+
 class HyperTree(Tree):
     """Tree of higher-dimensional regions.
 

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -70,14 +70,13 @@ def forest_from_peaks(
     getextremum=attrgetter("extremum"),
     getargext=attrgetter("argext"),
 ):
-    """Return (parent, roots, children, tip) from peak regions having start, istop, cutoff, extremum, argext."""
+    """Return (roots, children, tip) from peak regions having start, istop, cutoff, extremum, argext."""
 
-    def sort_and_tuple(alist):
+    def sorted_tuple(alist):
         alist.sort(key=getstart)
         alist.sort(key=getextremum, reverse=not reverse)
         return tuple(alist)
 
-    parent = {}
     children = {}
     tip = {}
     in_spe = []
@@ -91,17 +90,14 @@ def forest_from_peaks(
         while in_spe and getstart(p) <= getstart(in_spe[-1]):
             c = in_spe.pop()
             children[p].append(c)
-            parent[c] = p
-        children[p] = sort_and_tuple(children[p])
+        children[p] = sorted_tuple(children[p])
         if children[p] and getargext(children[p][0]) == getargext(p):
             tip[p] = tip[children[p][0]]
         else:
             tip[p] = p
         in_spe.append(p)
-    roots = sort_and_tuple(in_spe)
-    for root in roots:
-        parent[root] = None
-    return parent, roots, children, tip
+    roots = sorted_tuple(in_spe)
+    return roots, children, tip
 
 
 # Classes:
@@ -130,6 +126,11 @@ class Tree:
        Biology 3, 10 (2008).
        Open access: https://doi.org/10.1186/1748-7188-3-10
     """
+
+    # Class variables and class methods:
+
+    getcutoff = attrgetter("cutoff")
+    getextremum = attrgetter("extremum")
 
     @classmethod
     def from_peaks(cls, peaks, **kwargs):
@@ -284,7 +285,7 @@ class Tree:
 
     def size(self, node):
         """Return vertical size of given node (max minus min)."""
-        return abs(node.extremum - node.cutoff)
+        return abs(Tree.getextremum(node) - Tree.getcutoff(node))
 
     def parent(self, node):
         """Return the parent (containing region) or None."""
@@ -493,29 +494,33 @@ class Forest:
        Open access: https://doi.org/10.1186/1748-7188-3-10
     """
 
+    # Class variables and class methods:
+
+    getcutoff = attrgetter("cutoff")
+    getextremum = attrgetter("extremum")
+    getargext = attrgetter("argext")
+
     @classmethod
     def from_peaks(cls, peaks, **kwargs):
         """Return new Forest from iterable of peak regions."""
         obj = cls.__new__(cls)
-        obj._parent, obj._roots, obj._children, obj._tip = forest_from_peaks(
-            peaks, **kwargs
-        )
-        obj._find_full()
+        obj._roots, obj._children, obj._tip = forest_from_peaks(peaks, **kwargs)
+        obj._find_full_parent()
         return obj
 
     @classmethod
     def from_valleys(cls, valleys, **kwargs):
         """Return new Forest from iterable of valley regions."""
         obj = cls.__new__(cls)
-        obj._parent, obj._roots, obj._children, obj._tip = forest_from_peaks(
+        obj._roots, obj._children, obj._tip = forest_from_peaks(
             valleys, reverse=True, **kwargs
         )
-        obj._find_full()
+        obj._find_full_parent()
         return obj
 
     @classmethod
     def from_levels(cls, levelsdict, /):
-        """Return new Tree from other tree's levels-dict."""
+        """Return new Forest from other forest's levels-dict."""
 
         def _make_tip(node):
             # full path shares this tip
@@ -551,7 +556,9 @@ class Forest:
             elif b == a + 1:
                 children[A] = [B]  # B is the first child of A
                 obj._parent[B] = A
-                if A.argext == stack[-1].argext:  # main path continues
+                if Forest.getargext(A) == Forest.getargext(
+                    stack[-1]
+                ):  # main path continues
                     obj._full[B] = obj._full[A]
                 else:  # main path ends at A
                     _make_tip(A)
@@ -568,6 +575,8 @@ class Forest:
         obj._children = {p: tuple(c) for p, c in children.items()}
         obj._roots = tuple(obj._roots)
         return obj
+
+    # dunder methods:
 
     def __init__(self, data):
         pass  # TODO
@@ -608,6 +617,8 @@ class Forest:
                 indent.append("│ ")
         return "\n".join(lines)
 
+    # whole forest methods:
+
     def as_dict_of_dicts(self):
         """Return data attributes as a dict of dicts."""
         rootsdict = {node: root for root in self._roots for node in self.subtree(root)}
@@ -634,17 +645,7 @@ class Forest:
         self._roots = tuple(_new(root) for root in self._roots)
         return None
 
-    def levels(self, localroot=None, level=0):
-        """Yield ordered sequence of (node, level) tuples (roots are zero level)."""
-        # defaults:
-        if localroot is None:
-            roots = self.roots()
-        else:
-            roots = (localroot,)
-        for root in roots:
-            yield (root, level)
-            for child in self.children(root):
-                yield from self.levels(child, level + 1)
+    # node methods:
 
     def root(self):
         """Return root if one tree else None."""
@@ -668,7 +669,7 @@ class Forest:
 
     def size(self, node):
         """Return vertical size of given node (max minus min)."""
-        return abs(node.extremum - node.cutoff)
+        return abs(Forest.getextremum(node) - Forest.getcutoff(node))
 
     def parent(self, node):
         """Return the parent (containing region) or None."""
@@ -696,12 +697,7 @@ class Forest:
         """Return the largest region with same argext as the given node."""
         return self._full[node]
 
-    def _index(self, node):
-        """Return the zero-based index of the given node."""
-        # accessing the preserved insertion order:
-        return list(self._full).index(node)
-
-    # public recursive algorithms:
+    # generator methods (yielding nodes):
 
     def path(self, start, istop, step):
         """Yield nodes on a path in the tree."""
@@ -733,6 +729,18 @@ class Forest:
             yield root
             for child in self.children(root):
                 yield from self.subtree(child)
+
+    def levels(self, localroot=None, level=0):
+        """Yield ordered sequence of (node, level) tuples (roots are zero level)."""
+        # defaults:
+        if localroot is None:
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for root in roots:
+            yield (root, level)
+            for child in self.children(root):
+                yield from self.levels(child, level + 1)
 
     def main_descendants(self, localroot=None):
         """Yield main child nodes in forest or given subtree."""
@@ -851,18 +859,31 @@ class Forest:
         for root in roots:
             yield from _yield_or_branch(root)
 
-    # Initialization algorithms:
+    # Implementation details (may change):
 
-    def _find_full(self):
-        """Compute attribute: self._full."""
+    def _index(self, node):
+        """Return the zero-based index of the given node."""
+        # accessing the preserved insertion order:
+        return list(self._full).index(node)
 
-        def _fullnodes():
-            yield from self.roots()
-            yield from self.lateral_descendants()
+    def _find_full_parent(self):
+        """Compute attributes: self._full self._parent."""
 
-        self._full = {
-            node: full for full in _fullnodes() for node in self.main_path(full)
-        }
+        def _make_parent(node):
+            for child in self.children(node):
+                self._parent[child] = node
+                if self.tip(node) == self.tip(child):
+                    self._full[child] = self._full[node]
+                else:
+                    self._full[child] = child
+                _make_parent(child)
+
+        self._parent = {}
+        self._full = {}
+        for root in self.roots():
+            self._parent[root] = None
+            self._full[root] = root
+            _make_parent(root)
 
 
 class HyperTree(Tree):

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -561,37 +561,49 @@ class Forest:
         obj._tip = {}
         obj._full = {}
         obj._roots = []
-        stack = []
-        for (A, a), (B, b) in pairwise(levelsdict.items()):
-            if not stack:
-                _make_root(A)  # the first element is a root
-                stack = [A]
-            if b == 0:  # B is a root
-                _make_leaf(A)
-                _make_root(B)
-                stack = [B]
-            elif b == a + 1:
-                children[A] = [B]  # B is the first child of A
-                obj._parent[B] = A
-                if Forest.getargext(A) == Forest.getargext(
-                    stack[-1]
-                ):  # main path continues
-                    obj._full[B] = obj._full[A]
-                else:  # main path ends at A
-                    _make_tip(A)
+        if len(levelsdict) == 0:
+            obj._roots = ()
+            return obj
+        elif len(levelsdict) == 1:
+            root, _ = levelsdict.popitem()
+            obj._parent[root] = None
+            obj._children = {root: ()}
+            obj._tip[root] = root
+            obj._full[root] = root
+            obj._roots = (root,)
+            return obj
+        else:  # len(levelsdict) > 1
+            stack = []
+            for (A, a), (B, b) in pairwise(levelsdict.items()):
+                if not stack:
+                    _make_root(A)  # the first element is a root
+                    stack = [A]
+                if b == 0:  # B is a root
+                    _make_leaf(A)
+                    _make_root(B)
+                    stack = [B]
+                elif b == a + 1:
+                    children[A] = [B]  # B is the first child of A
+                    obj._parent[B] = A
+                    if Forest.getargext(A) == Forest.getargext(
+                        stack[-1]
+                    ):  # main path continues
+                        obj._full[B] = obj._full[A]
+                    else:  # main path ends at A
+                        _make_tip(A)
+                        obj._full[B] = B
+                    stack.append(B)
+                else:  # then a >= b > 0:
+                    _make_leaf(A)  # A is a leaf and tip
                     obj._full[B] = B
-                stack.append(B)
-            else:  # then a >= b > 0:
-                _make_leaf(A)  # A is a leaf and tip
-                obj._full[B] = B
-                del stack[b:]  # remove finished nodes
-                children[stack[-1]].append(B)  # B is a lateral child
-                obj._parent[B] = stack[-1]
-                stack.append(B)
-        _make_leaf(B)  # the last element is a leaf and tip
-        obj._children = {p: tuple(c) for p, c in children.items()}
-        obj._roots = tuple(obj._roots)
-        return obj
+                    del stack[b:]  # remove finished nodes
+                    children[stack[-1]].append(B)  # B is a lateral child
+                    obj._parent[B] = stack[-1]
+                    stack.append(B)
+            _make_leaf(B)  # the last element is a leaf and tip
+            obj._children = {p: tuple(c) for p, c in children.items()}
+            obj._roots = tuple(obj._roots)
+            return obj
 
     # dunder methods:
 
@@ -865,7 +877,7 @@ class Forest:
         else:
             roots = (localroot,)
         if maxsize is None:
-            maxsize = 0.2 * max(self.size(root) for root in self.roots())
+            maxsize = 0.2 * max((self.size(root) for root in self.roots()), default=0)
         # The 'MAXDEEP algorithm' in reverse:
         for root in roots:
             for climber in self.main_path(root):
@@ -1313,7 +1325,7 @@ class HyperForest(Forest):
         else:
             roots = (localroot,)
         if maxsize is None:
-            maxsize = 0.2 * max(self.size(root) for root in self.roots())
+            maxsize = 0.2 * max((self.size(root) for root in self.roots()), default=0)
         for ra, rb in roots:
             for a in self.L.size_filter(maxsize=maxsize, localroot=ra):
                 for b in self.R.size_filter(maxsize=maxsize, localroot=rb):

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -129,6 +129,8 @@ class Tree:
 
     # Class variables and class methods:
 
+    getstart = attrgetter("start")
+    getistop = attrgetter("istop")
     getcutoff = attrgetter("cutoff")
     getextremum = attrgetter("extremum")
 
@@ -186,8 +188,18 @@ class Tree:
         obj._children = {p: tuple(c) for p, c in children.items()}
         return obj
 
-    def __init__(self, data):
-        pass  # TODO
+    def __init__(self, peaks, *, are_valleys=False, presorted=False):
+        """Initialize Tree from iterable of peak (or valley) regions."""
+        self._parent, self._root, self._children, self._tip = tree_from_peaks(
+            peaks,
+            presorted=presorted,
+            reverse=are_valleys,
+            getstart=Tree.getstart,
+            getistop=Tree.getistop,
+            getcutoff=Tree.getcutoff,
+            getextremum=Tree.getextremum,
+        )
+        self._find_full()
 
     def __contains__(self, node):
         """Return True if the input is a node in the Tree."""
@@ -496,6 +508,8 @@ class Forest:
 
     # Class variables and class methods:
 
+    getstart = attrgetter("start")
+    getistop = attrgetter("istop")
     getcutoff = attrgetter("cutoff")
     getextremum = attrgetter("extremum")
     getargext = attrgetter("argext")
@@ -504,6 +518,7 @@ class Forest:
     def from_peaks(cls, peaks, **kwargs):
         """Return new Forest from iterable of peak regions."""
         obj = cls.__new__(cls)
+        obj.are_valleys = False
         obj._roots, obj._children, obj._tip = forest_from_peaks(peaks, **kwargs)
         obj._find_full_parent()
         return obj
@@ -512,6 +527,7 @@ class Forest:
     def from_valleys(cls, valleys, **kwargs):
         """Return new Forest from iterable of valley regions."""
         obj = cls.__new__(cls)
+        obj.are_valleys = True
         obj._roots, obj._children, obj._tip = forest_from_peaks(
             valleys, reverse=True, **kwargs
         )
@@ -519,7 +535,7 @@ class Forest:
         return obj
 
     @classmethod
-    def from_levels(cls, levelsdict, /):
+    def from_levels(cls, levelsdict, /, *, are_valleys=False):
         """Return new Forest from other forest's levels-dict."""
 
         def _make_tip(node):
@@ -539,6 +555,7 @@ class Forest:
             obj._roots.append(node)
 
         obj = cls.__new__(cls)
+        obj.are_valleys = are_valleys
         obj._parent = {}
         children = {}
         obj._tip = {}
@@ -578,27 +595,39 @@ class Forest:
 
     # dunder methods:
 
-    def __init__(self, data):
-        pass  # TODO
+    def __init__(self, peaks, *, are_valleys=False, presorted=False):
+        """Initialize Forest from iterable of peak (or valley) regions."""
+        self.are_valleys = are_valleys
+        self._roots, self._children, self._tip = forest_from_peaks(
+            peaks,
+            presorted=presorted,
+            reverse=are_valleys,
+            getstart=Forest.getstart,
+            getistop=Forest.getistop,
+            getcutoff=Forest.getcutoff,
+            getextremum=Forest.getextremum,
+            getargext=Forest.getargext,
+        )
+        self._find_full_parent()
 
     def __contains__(self, node):
-        """Return True if the input is a node in the Tree."""
+        """Return True if the input is a node in the Forest."""
         return node in self._full
 
     def __iter__(self):
-        """Iterate over nodes in the Tree."""
+        """Iterate over nodes in the Forest."""
         return iter(self._full)
 
     def __len__(self):
-        """Return number of nodes in the Tree."""
+        """Return number of nodes in the Forest."""
         return len(self._full)
 
     def __repr__(self) -> str:
         """Return string that can reconstruct the Forest."""
-        return f"Forest.from_levels({repr(dict(self.levels()))})"
+        return f"Forest.from_levels({repr(dict(self.levels()))}, are_valleys={self.are_valleys})"
 
     def __str__(self):
-        """Return tree as string using box drawing characters."""
+        """Return Forest as string using box drawing characters."""
         indent = [""]
         lines = []
         for node, level in self.levels():
@@ -616,6 +645,30 @@ class Forest:
                 lines.append("".join([*indent, "├─", str(node)]))
                 indent.append("│ ")
         return "\n".join(lines)
+
+    def __sub__(self, other):
+        """Return new Forest of nodes in self not other (difference)."""
+        return Forest(
+            set(self) - set(other), are_valleys=self.are_valleys, presorted=False
+        )
+
+    def __and__(self, other):
+        """Return new Forest of nodes in self and other (intersection)."""
+        return Forest(
+            set(self) & set(other), are_valleys=self.are_valleys, presorted=False
+        )
+
+    def __or__(self, other):
+        """Return new Forest of nodes in self or other (union)."""
+        return Forest(
+            set(self) | set(other), are_valleys=self.are_valleys, presorted=False
+        )
+
+    def __xor__(self, other):
+        """Return new Forest of nodes in either self or other (symmetric difference)."""
+        return Forest(
+            set(self) ^ set(other), are_valleys=self.are_valleys, presorted=False
+        )
 
     # whole forest methods:
 

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -59,6 +59,51 @@ def tree_from_peaks(
     return parent, root, children, tip
 
 
+def forest_from_peaks(
+    peaks,
+    *,
+    presorted=False,
+    reverse=False,
+    getstart=attrgetter("start"),
+    getistop=attrgetter("istop"),
+    getcutoff=attrgetter("cutoff"),
+    getextremum=attrgetter("extremum"),
+    getargext=attrgetter("argext"),
+):
+    """Return (parent, roots, children, tip) from peak regions having start, istop, cutoff, extremum, argext."""
+
+    def sort_and_tuple(alist):
+        alist.sort(key=getstart)
+        alist.sort(key=getextremum, reverse=not reverse)
+        return tuple(alist)
+
+    parent = {}
+    children = {}
+    tip = {}
+    in_spe = []
+    if not presorted:
+        peaks = list(peaks)
+        # Order same as given by 'find_peaks' function:
+        peaks.sort(key=getcutoff, reverse=not reverse)
+        peaks.sort(key=getistop)
+    for p in peaks:
+        children[p] = []
+        while in_spe and getstart(p) <= getstart(in_spe[-1]):
+            c = in_spe.pop()
+            children[p].append(c)
+            parent[c] = p
+        children[p] = sort_and_tuple(children[p])
+        if children[p] and getargext(children[p][0]) == getargext(p):
+            tip[p] = tip[children[p][0]]
+        else:
+            tip[p] = p
+        in_spe.append(p)
+    roots = sort_and_tuple(in_spe)
+    for root in roots:
+        parent[root] = None
+    return parent, roots, children, tip
+
+
 # Classes:
 
 

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -1187,16 +1187,10 @@ class HyperForest(Forest):
     def __contains__(self, pair):
         """Return True if the input is a node in the HyperForest."""
         a, b = pair
-        # test if (a, b) is 'parent-above' or 'below-leaf':
+        # test if (a, b) is 'parent-above':
         return (
-            a in self.L.roots()
-            or self.L.size(self.L.parent(a)) > self.R.size(b)
-            or (not self.R.has_children(b) and self.R.size(b) >= self.L.size(a))
-        ) and (
-            b in self.R.roots()
-            or self.R.size(self.R.parent(b)) > self.L.size(a)
-            or (not self.L.has_children(a) and self.L.size(a) >= self.R.size(b))
-        )
+            a in self.L.roots() or self.L.size(self.L.parent(a)) > self.R.size(b)
+        ) and (b in self.R.roots() or self.R.size(self.R.parent(b)) > self.L.size(a))
 
     def __iter__(self):
         """Iterate over nodes in the HyperForest."""
@@ -1232,17 +1226,17 @@ class HyperForest(Forest):
     def has_children(self, node):
         """Return True if given node has children."""
         a, b = node
-        return self.L.has_children(a) or self.R.has_children(b)
+        if self.L.size(a) > self.R.size(b):
+            return self.L.has_children(a)
+        elif self.L.size(a) < self.R.size(b):
+            return self.R.has_children(b)
+        elif self.L.size(a) == self.R.size(b):
+            return self.L.has_children(a) and self.R.has_children(b)
 
     def size(self, node):
         """Return the given node's size."""
         a, b = node
-        if (not self.L.has_children(a) and self.L.size(a) > self.R.size(b)) or (
-            not self.R.has_children(b) and self.L.size(a) < self.R.size(b)
-        ):
-            return min(self.L.size(a), self.R.size(b))
-        else:
-            return max(self.L.size(a), self.R.size(b))
+        return max(self.L.size(a), self.R.size(b))
 
     def parent(self, node):
         """Return the given node's parent or None."""
@@ -1267,33 +1261,29 @@ class HyperForest(Forest):
     def children(self, node):
         """Return the given node's children."""
         a, b = node
-        if self.L.has_children(a) and self.R.has_children(b):
-            if self.L.size(a) > self.R.size(b):
-                return tuple((ca, b) for ca in self.L.children(a))
-            elif self.L.size(a) < self.R.size(b):
-                return tuple((a, cb) for cb in self.R.children(b))
-            elif self.L.size(a) == self.R.size(b):
-                return tuple(
-                    (ca, cb) for ca in self.L.children(a) for cb in self.R.children(b)
-                )
-        elif not self.L.has_children(a) and not self.R.has_children(b):
-            return ()
-        elif self.L.has_children(a):
+        if self.L.size(a) > self.R.size(b) and self.L.has_children(a):
             return tuple((ca, b) for ca in self.L.children(a))
-        else:
+        elif self.L.size(a) < self.R.size(b) and self.R.has_children(b):
             return tuple((a, cb) for cb in self.R.children(b))
+        elif (
+            self.L.size(a) == self.R.size(b)
+            and self.L.has_children(a)
+            and self.R.has_children(b)
+        ):
+            return tuple(
+                (ca, cb) for ca in self.L.children(a) for cb in self.R.children(b)
+            )
+        else:
+            return ()
 
     def main_child(self, node):
         """Return the main child (the child that has the same tip)."""
         a, b = node
-        if (children := self.children(node)) == ():
-            return None
-        else:
-            a1, b1 = children[0]
+        if self.has_children(node):
+            a1, b1 = self.children(node)[0]
             if self.L.tip(a1) == self.L.tip(a) and self.R.tip(b1) == self.R.tip(b):
                 return a1, b1
-            else:
-                return None
+        return None
 
     def full(self, node):
         """Return the largest node with same tip as given node."""
@@ -1304,18 +1294,6 @@ class HyperForest(Forest):
         return climber
 
     # generator methods (yielding nodes):
-
-    def leaf_nodes(self, localroot=None):
-        """Yield leaf nodes."""
-        # defaults:
-        if localroot is None:
-            roots = self.roots()
-        else:
-            roots = (localroot,)
-        for ra, rb in roots:
-            for a in self.L.leaf_nodes(localroot=ra):
-                for b in self.R.leaf_nodes(localroot=rb):
-                    yield a, b
 
     def size_filter(self, localroot=None, *, maxsize=None):
         """Yield grid nodes in given subtree."""

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -646,6 +646,10 @@ class Forest:
                 indent.append("│ ")
         return "\n".join(lines)
 
+    def __matmul__(self, other):
+        """Return product self @ other (other is a Forest or HyperForest)."""
+        return HyperForest(self, other)
+
     def __sub__(self, other):
         """Return new Forest of nodes in self not other (difference)."""
         return Forest(
@@ -700,9 +704,18 @@ class Forest:
 
     # node methods:
 
-    def root(self):
-        """Return root if one tree else None."""
-        return self._roots[0] if len(self._roots) == 1 else None
+    def root(self, node=None):
+        """Return root of single tree, root of given node, or None."""
+        if len(self.roots()) == 1:
+            return self.roots()[0]
+        elif node is not None and len(self.roots()) > 1:
+            climber = node
+            while self.is_nonroot(climber):
+                climber = self.parent(climber)
+                climber = self.full(climber)
+            return climber
+        else:
+            return None
 
     def roots(self):
         """Return tuple of roots of trees in forest."""
@@ -741,10 +754,10 @@ class Forest:
 
     def lateral(self, node):
         """Return ordered tuple of the given node's lateral children."""
-        if node == self._tip[node]:
-            return self._children[node]
+        if node == self.tip(node):
+            return self.children(node)
         else:
-            return self._children[node][1:]
+            return self.children(node)[1:]
 
     def full(self, node):
         """Return the largest region with same argext as the given node."""
@@ -762,10 +775,7 @@ class Forest:
 
     def root_path(self, node):
         """Yield nodes on the parent path from given node to its root."""
-        yield node
-        while self.is_nonroot(node):
-            node = self.parent(node)
-            yield node
+        yield from self.path(node, self.root(node), self.parent)
 
     def main_path(self, node):
         """Yield nodes on the main_child path from given node to its tip."""
@@ -877,7 +887,9 @@ class Forest:
         else:
             roots = (localroot,)
         filter = list(nodes)
-        countdown = {n: len(self.children(n)) for n in self.subtree(localroot)}
+        countdown = {
+            n: len(self.children(n)) for root in roots for n in self.subtree(root)
+        }
 
         # Recursive "bottom-up" search via parents:
         def _yield_or_propagate(node):
@@ -889,8 +901,9 @@ class Forest:
                 if countdown[parent] == 0:
                     yield from _yield_or_propagate(parent)
 
-        for node in self.leaf_nodes(localroot):
-            yield from _yield_or_propagate(node)
+        for root in roots:
+            for node in self.leaf_nodes(root):
+                yield from _yield_or_propagate(node)
 
     def outermost(self, nodes, localroot=None):
         """Yield outermost nodes of the given nodes."""
@@ -1124,24 +1137,24 @@ class HyperTree(Tree):
 
 
 class HyperForest(Forest):
-    """Tree of higher-dimensional regions.
+    """Forest of trees of higher-dimensional regions.
 
-    A HyperTree represents the hierarchical nesting of peak regions
-    or valley regions in more dimensions, such as a mountain landscape
+    A HyperForest represents the hierarchical nesting of peak regions
+    or valley regions in more dimensions, for example, a mountain landscape
     with height z as a function of x and y.
 
-    A HyperTree assumes dimensional decoupling, i.e. the landscape is a
-    sum z(x,y) = f(x) + g(y) or a product z(x,y) = f(x) * g(y).
+    A HyperForest assumes dimensional decoupling, for example, a
+    landscape z(x, y) that is a sum f(x) + g(y) or product f(x) * g(y).
 
-    A HyperTree is constructed as a pair of trees that are
-    of type Tree or HyperTree.
+    A HyperForest is constructed as a pair of forests that are
+    of type Forest or HyperForest.
 
-    A HyperTree is a kind of product tree, but it is not the Cartesian
+    A HyperForest is a kind of product tree, but it is not a Cartesian
     product.
 
     Notes
     -----
-    Background literature for the HyperTree class is
+    Background literature for the HyperForest class is
     the subsection titled "2D peaks" in the article [1]_.
 
     References
@@ -1152,33 +1165,44 @@ class HyperForest(Forest):
        Open access: https://doi.org/10.1186/1748-7188-3-10
     """
 
-    def __init__(self, left_tree, right_tree):
-        self.L = left_tree
-        self.R = right_tree
+    # dunder methods:
+
+    def __init__(self, left_forest, right_forest):
+        """Initialize HyperForest from pair of Forest or HyperForest objects."""
+        self.L = left_forest
+        self.R = right_forest
 
     def __contains__(self, pair):
-        """Return True if the input is a node in the HyperTree."""
+        """Return True if the input is a node in the HyperForest."""
         a, b = pair
-        # test if (a, b) is 'parent-above':
+        # test if (a, b) is 'parent-above' or 'below-leaf':
         return (
-            a == self.L.root() or self.L.size(self.L.parent(a)) > self.R.size(b)
-        ) and (b == self.R.root() or self.R.size(self.R.parent(b)) > self.L.size(a))
+            a in self.L.roots()
+            or self.L.size(self.L.parent(a)) > self.R.size(b)
+            or (not self.R.has_children(b) and self.R.size(b) >= self.L.size(a))
+        ) and (
+            b in self.R.roots()
+            or self.R.size(self.R.parent(b)) > self.L.size(a)
+            or (not self.L.has_children(a) and self.L.size(a) >= self.R.size(b))
+        )
 
     def __iter__(self):
-        """Iterate over nodes in the HyperTree."""
+        """Iterate over nodes in the HyperForest."""
         yield from self.subtree()
 
     def __len__(self):
-        """Return number of nodes in the HyperTree."""
+        """Return number of nodes in the HyperForest."""
         return len(list(self.__iter__()))
 
     def __repr__(self) -> str:
-        """Return string that can reconstruct the HyperTree."""
-        return f"HyperTree({repr(self.L)}, {repr(self.R)})"
+        """Return string that can reconstruct the HyperForest."""
+        return f"HyperForest({repr(self.L)}, {repr(self.R)})"
 
-    def root(self):
-        """Return the root node of the HyperTree."""
-        return (self.L.root(), self.R.root())
+    # node methods:
+
+    def roots(self):
+        """Return tuple of roots of trees in HyperForest."""
+        return tuple((a, b) for a in self.L.roots() for b in self.R.roots())
 
     def is_nonroot(self, node):
         """Return True if given node has a parent."""
@@ -1188,7 +1212,10 @@ class HyperForest(Forest):
     def tip(self, node):
         """Return the given node's tip node."""
         a, b = node
-        return (self.L.tip(a), self.R.tip(b))
+        climber = (self.L.tip(a), self.R.tip(b))
+        while climber not in self:
+            climber = self.parent(climber)
+        return climber
 
     def has_children(self, node):
         """Return True if given node has children."""
@@ -1198,7 +1225,12 @@ class HyperForest(Forest):
     def size(self, node):
         """Return the given node's size."""
         a, b = node
-        return max(self.L.size(a), self.R.size(b))
+        if (not self.L.has_children(a) and self.L.size(a) > self.R.size(b)) or (
+            not self.R.has_children(b) and self.L.size(a) < self.R.size(b)
+        ):
+            return min(self.L.size(a), self.R.size(b))
+        else:
+            return max(self.L.size(a), self.R.size(b))
 
     def parent(self, node):
         """Return the given node's parent or None."""
@@ -1223,64 +1255,78 @@ class HyperForest(Forest):
     def children(self, node):
         """Return the given node's children."""
         a, b = node
-        if not self.has_children(node):
+        if self.L.has_children(a) and self.R.has_children(b):
+            if self.L.size(a) > self.R.size(b):
+                return tuple((ca, b) for ca in self.L.children(a))
+            elif self.L.size(a) < self.R.size(b):
+                return tuple((a, cb) for cb in self.R.children(b))
+            elif self.L.size(a) == self.R.size(b):
+                return tuple(
+                    (ca, cb) for ca in self.L.children(a) for cb in self.R.children(b)
+                )
+        elif not self.L.has_children(a) and not self.R.has_children(b):
             return ()
-        elif self.L.size(a) > self.R.size(b):
+        elif self.L.has_children(a):
             return tuple((ca, b) for ca in self.L.children(a))
-        elif self.L.size(a) < self.R.size(b):
+        else:
             return tuple((a, cb) for cb in self.R.children(b))
-        elif self.L.size(a) == self.R.size(b):
-            return tuple(
-                (ca, cb) for ca in self.L.children(a) for cb in self.R.children(b)
-            )
 
     def main_child(self, node):
         """Return the main child (the child that has the same tip)."""
         a, b = node
-        if not self.has_children(node):
+        if (children := self.children(node)) == ():
             return None
-        elif self.L.size(a) > self.R.size(b):
-            return (self.L.main_child(a), b)
-        elif self.L.size(a) < self.R.size(b):
-            return (a, self.R.main_child(b))
-        elif self.L.size(a) == self.R.size(b):
-            return (self.L.main_child(a), self.R.main_child(b))
+        else:
+            a1, b1 = children[0]
+            if self.L.tip(a1) == self.L.tip(a) and self.R.tip(b1) == self.R.tip(b):
+                return a1, b1
+            else:
+                return None
 
     def full(self, node):
         """Return the largest node with same tip as given node."""
-        climber = node
-        while self.is_nonroot(climber) and self.tip(climber) == self.tip(
-            nextstep := self.parent(climber)
-        ):
-            climber = nextstep
+        a, b = node
+        climber = (self.L.full(a), self.R.full(b))
+        while climber not in self:
+            climber = self.main_child(climber)
         return climber
+
+    # generator methods (yielding nodes):
+
+    def leaf_nodes(self, localroot=None):
+        """Yield leaf nodes."""
+        # defaults:
+        if localroot is None:
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for ra, rb in roots:
+            for a in self.L.leaf_nodes(localroot=ra):
+                for b in self.R.leaf_nodes(localroot=rb):
+                    yield a, b
+
+    def size_filter(self, localroot=None, *, maxsize=None):
+        """Yield grid nodes in given subtree."""
+        # defaults:
+        if localroot is None:
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        if maxsize is None:
+            maxsize = 0.2 * max(self.size(root) for root in self.roots())
+        for ra, rb in roots:
+            for a in self.L.size_filter(maxsize=maxsize, localroot=ra):
+                for b in self.R.size_filter(maxsize=maxsize, localroot=rb):
+                    yield a, b
+
+    # Implementation details (may change):
 
     def _index(self, node):
         """Return a tuple of (nested) indices for given node."""
         a, b = node
         return self.L._index(a), self.R._index(b)
 
-    def leaf_nodes(self, localroot=None):
-        """Yield leaf nodes."""
-        # defaults:
-        if localroot is None:
-            localroot = self.root()
-        ra, rb = localroot
-        for a in self.L.leaf_nodes(localroot=ra):
-            for b in self.R.leaf_nodes(localroot=rb):
-                yield a, b
-
-    def size_filter(self, localroot=None, *, maxsize=None):
-        """Yield grid nodes in given subtree."""
-        # defaults:
-        if localroot is None:
-            localroot = self.root()
-        if maxsize is None:
-            maxsize = 0.2 * max(self.L.size(self.L.root()), self.R.size(self.R.root()))
-        ra, rb = localroot
-        for a in self.L.size_filter(maxsize=maxsize, localroot=ra):
-            for b in self.R.size_filter(maxsize=maxsize, localroot=rb):
-                yield a, b
+    # Forest methods that are not HyperForest methods:
 
     def from_peaks(self):
         """Return that it is NotImplemented."""
@@ -1302,6 +1348,22 @@ class HyperForest(Forest):
         """Return that it is NotImplemented."""
         return NotImplemented
 
-    def _find_full(self):
+    def _find_full_parent(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def __sub__(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def __and__(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def __or__(self):
+        """Return that it is NotImplemented."""
+        return NotImplemented
+
+    def __xor__(self):
         """Return that it is NotImplemented."""
         return NotImplemented

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -266,6 +266,10 @@ class Tree:
         """Return the root node of the Tree."""
         return self._root
 
+    def roots(self):
+        """Return tuple with the root node of the Tree."""
+        return (self.root(),)
+
     def is_nonroot(self, node):
         """Return True if the given node has a parent."""
         return node != self._root

--- a/peakoscope/trees.py
+++ b/peakoscope/trees.py
@@ -462,19 +462,23 @@ class Tree:
 
 
 class Forest:
-    """Tree of regions in univariate data.
+    """Trees of regions in univariate data.
 
-    A Tree represents the hierarchical nesting of
+    A Forest represents the hierarchical nesting of
     peak or valley regions in 1D data such as a sequence of numbers,
     a time series, a function y(x) or other univariate data.
 
-    A Tree is initialized with an iterable of regions
-    that have start, istop, cutoff, extremum. The regions
-    must be unique hashable objects to be used as dictionary keys.
+    A Forest is initialized with an iterable of regions
+    that have start, istop, cutoff, extremum, argext. The regions
+    must be unique hashable objects to be used as dictionary keys
+    and they become the tree nodes.
+
+    A Forest consists of zero, one or more trees with a root each.
+    But a Forest is a container of tree nodes, not trees.
 
     Notes
     -----
-    Background literature for the Tree class is
+    Background literature for the Forest class is
     the subsection titled "1D peaks" in the article [1]_.
 
     References
@@ -487,9 +491,9 @@ class Forest:
 
     @classmethod
     def from_peaks(cls, peaks, **kwargs):
-        """Return new Tree from iterable of peak regions."""
+        """Return new Forest from iterable of peak regions."""
         obj = cls.__new__(cls)
-        obj._parent, obj._root, obj._children, obj._tip = tree_from_peaks(
+        obj._parent, obj._roots, obj._children, obj._tip = forest_from_peaks(
             peaks, **kwargs
         )
         obj._find_full()
@@ -497,9 +501,9 @@ class Forest:
 
     @classmethod
     def from_valleys(cls, valleys, **kwargs):
-        """Return new Tree from iterable of valley regions."""
+        """Return new Forest from iterable of valley regions."""
         obj = cls.__new__(cls)
-        obj._parent, obj._root, obj._children, obj._tip = tree_from_peaks(
+        obj._parent, obj._roots, obj._children, obj._tip = forest_from_peaks(
             valleys, reverse=True, **kwargs
         )
         obj._find_full()
@@ -509,34 +513,56 @@ class Forest:
     def from_levels(cls, levelsdict, /):
         """Return new Tree from other tree's levels-dict."""
 
-        def leaf_and_tip(node):
-            children[node] = []
+        def _make_tip(node):
+            # full path shares this tip
             for n in obj.path(node, obj._full[node], obj.parent):
                 obj._tip[n] = node
+
+        def _make_leaf(node):
+            # has no children and is tip
+            children[node] = []
+            _make_tip(node)
+
+        def _make_root(node):
+            # has no parent and is full
+            obj._parent[node] = None
+            obj._full[node] = node
+            obj._roots.append(node)
 
         obj = cls.__new__(cls)
         obj._parent = {}
         children = {}
         obj._tip = {}
         obj._full = {}
+        obj._roots = []
+        stack = []
         for (A, a), (B, b) in pairwise(levelsdict.items()):
-            if a == 0:  # first item is the root:
-                obj._parent[A] = None
-                obj._full[A] = A
-                obj._root = A
+            if not stack:
+                _make_root(A)  # the first element is a root
                 stack = [A]
-            if b == a + 1:  # a subtree grows:
-                obj._full[B] = obj._full[A]
-                children[stack[-1]] = [B]  # B is the main child (of A)
-            else:  # (then a >= b) a subtree finishes:
-                del stack[b:]  # pop a slice
+            if b == 0:  # B is a root
+                _make_leaf(A)
+                _make_root(B)
+                stack = [B]
+            elif b == a + 1:
+                children[A] = [B]  # B is the first child of A
+                obj._parent[B] = A
+                if A.argext == stack[-1].argext:  # main path continues
+                    obj._full[B] = obj._full[A]
+                else:  # main path ends at A
+                    _make_tip(A)
+                    obj._full[B] = B
+                stack.append(B)
+            else:  # then a >= b > 0:
+                _make_leaf(A)  # A is a leaf and tip
                 obj._full[B] = B
+                del stack[b:]  # remove finished nodes
                 children[stack[-1]].append(B)  # B is a lateral child
-                leaf_and_tip(A)  # A is a leaf and tip
-            obj._parent[B] = stack[-1]
-            stack.append(B)
-        leaf_and_tip(B)  # the last B is a leaf and tip
+                obj._parent[B] = stack[-1]
+                stack.append(B)
+        _make_leaf(B)  # the last element is a leaf and tip
         obj._children = {p: tuple(c) for p, c in children.items()}
+        obj._roots = tuple(obj._roots)
         return obj
 
     def __init__(self, data):
@@ -554,13 +580,9 @@ class Forest:
         """Return number of nodes in the Tree."""
         return len(self._full)
 
-    def __matmul__(self, other):
-        """Return product self @ other (other is a Tree or HyperTree)."""
-        return HyperTree(self, other)
-
     def __repr__(self) -> str:
-        """Return string that can reconstruct the Tree."""
-        return f"Tree.from_levels({repr(dict(self.levels()))})"
+        """Return string that can reconstruct the Forest."""
+        return f"Forest.from_levels({repr(dict(self.levels()))})"
 
     def __str__(self):
         """Return tree as string using box drawing characters."""
@@ -584,45 +606,53 @@ class Forest:
 
     def as_dict_of_dicts(self):
         """Return data attributes as a dict of dicts."""
+        rootsdict = {node: root for root in self._roots for node in self.subtree(root)}
         return {
             "_parent": self._parent,
             "_children": self._children,
             "_tip": self._tip,
             "_full": self._full,
-            "_root": self._root,
+            "_roots": rootsdict,
         }
 
     def set_nodes(self, changes={}):
-        """Replace Tree nodes by using given mapping."""
+        """Replace Forest nodes by using given mapping."""
 
-        def new(node):
+        def _new(node):
             return changes[node] if node in changes else node
 
-        self._tip = dict((new(x), new(y)) for (x, y) in self._tip.items())
-        self._full = dict((new(x), new(y)) for (x, y) in self._full.items())
-        self._parent = dict((new(x), new(y)) for (x, y) in self._parent.items())
+        self._tip = dict((_new(x), _new(y)) for (x, y) in self._tip.items())
+        self._full = dict((_new(x), _new(y)) for (x, y) in self._full.items())
+        self._parent = dict((_new(x), _new(y)) for (x, y) in self._parent.items())
         self._children = dict(
-            (new(x), tuple(new(z) for z in y)) for (x, y) in self._children.items()
+            (_new(x), tuple(_new(z) for z in y)) for (x, y) in self._children.items()
         )
-        self._root = new(self._root)
+        self._roots = tuple(_new(root) for root in self._roots)
         return None
 
     def levels(self, localroot=None, level=0):
-        """Yield ordered sequence of (node, level) tuples (root is zero level)."""
+        """Yield ordered sequence of (node, level) tuples (roots are zero level)."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
-        yield (localroot, level)
-        for child in self.children(localroot):
-            yield from self.levels(child, level + 1)
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for root in roots:
+            yield (root, level)
+            for child in self.children(root):
+                yield from self.levels(child, level + 1)
 
     def root(self):
-        """Return the root node of the Tree."""
-        return self._root
+        """Return root if one tree else None."""
+        return self._roots[0] if len(self._roots) == 1 else None
+
+    def roots(self):
+        """Return tuple of roots of trees in forest."""
+        return self._roots
 
     def is_nonroot(self, node):
         """Return True if the given node has a parent."""
-        return node != self._root
+        return node not in self._roots
 
     def tip(self, node):
         """Return the smallest region with same argext as the given node."""
@@ -630,7 +660,7 @@ class Forest:
 
     def has_children(self, node):
         """Return True if the given node has sub regions."""
-        return node != self._tip[node]
+        return bool(self._children[node])
 
     def size(self, node):
         """Return vertical size of given node (max minus min)."""
@@ -646,14 +676,17 @@ class Forest:
 
     def main_child(self, node):
         """Return child of given node with same argext, or None."""
-        if self.has_children(node):
-            return self.children(node)[0]
-        else:
+        if node == self._tip[node]:
             return None
+        else:
+            return self._children[node][0]
 
     def lateral(self, node):
         """Return ordered tuple of the given node's lateral children."""
-        return self.children(node)[1:]
+        if node == self._tip[node]:
+            return self._children[node]
+        else:
+            return self._children[node][1:]
 
     def full(self, node):
         """Return the largest region with same argext as the given node."""
@@ -676,98 +709,108 @@ class Forest:
 
     def root_path(self, node):
         """Yield nodes on the parent path from given node to its root."""
-        yield from self.path(node, self.root(), self.parent)
+        yield node
+        while self.is_nonroot(node):
+            node = self.parent(node)
+            yield node
 
     def main_path(self, node):
         """Yield nodes on the main_child path from given node to its tip."""
         yield from self.path(node, self.tip(node), self.main_child)
 
     def subtree(self, localroot=None):
-        """Yield all nodes in the given subtree."""
+        """Yield all nodes in forest or given subtree."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
-        yield localroot
-        for child in self.children(localroot):
-            yield from self.subtree(child)
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for root in roots:
+            yield root
+            for child in self.children(root):
+                yield from self.subtree(child)
 
     def main_descendants(self, localroot=None):
-        """Yield main child nodes in the given subtree."""
+        """Yield main child nodes in forest or given subtree."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
-        if self.has_children(localroot):
-            yield self.main_child(localroot)
-            for child in self.children(localroot):
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for root in roots:
+            if (mc := self.main_child(root)) is not None:
+                yield mc
+            for child in self.children(root):
                 yield from self.main_descendants(child)
 
     def lateral_descendants(self, localroot=None):
-        """Yield lateral child nodes in the given subtree."""
+        """Yield lateral child nodes in forest or given subtree."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
-        if self.has_children(localroot):
-            yield from self.lateral(localroot)
-            for child in self.children(localroot):
+            roots = self.roots()
+        else:
+            roots = (localroot,)
+        for root in roots:
+            yield from self.lateral(root)
+            for child in self.children(root):
                 yield from self.lateral_descendants(child)
 
     def full_nodes(self, localroot=None):
-        """Yield full nodes in the given subtree."""
+        """Yield full nodes in forest or given subtree."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
-        if localroot == self.full(localroot):
+            yield from self.roots()
+        elif localroot == self.full(localroot):
             yield localroot
         yield from self.lateral_descendants(localroot)
 
     def leaf_nodes(self, localroot=None):
-        """Yield subtree nodes that have no children."""
-        # defaults:
-        if localroot is None:
-            localroot = self.root()
+        """Yield forest or subtree nodes that have no children."""
         return (
             node for node in self.subtree(localroot) if len(self.children(node)) == 0
         )
 
     def branch_nodes(self, localroot=None):
-        """Yield subtree nodes that have two or more children."""
-        # defaults:
-        if localroot is None:
-            localroot = self.root()
+        """Yield forest or subtree nodes that have two or more children."""
         return (
             node for node in self.subtree(localroot) if len(self.children(node)) > 1
         )
 
     def linear_nodes(self, localroot=None):
-        """Yield subtree nodes that have one child."""
-        # defaults:
-        if localroot is None:
-            localroot = self.root()
+        """Yield forest or subtree nodes that have one child."""
         return (
             node for node in self.subtree(localroot) if len(self.children(node)) == 1
         )
 
     def size_filter(self, localroot=None, *, maxsize=None):
-        """Yield subtree nodes filtered by size."""
+        """Yield forest or subtree nodes filtered by size."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
+            roots = self.roots()
+        else:
+            roots = (localroot,)
         if maxsize is None:
-            maxsize = 0.2 * self.size(self.root())
+            maxsize = 0.2 * max(self.size(root) for root in self.roots())
         # The 'MAXDEEP algorithm' in reverse:
-        for climber in self.main_path(localroot):
-            if self.size(climber) >= maxsize:
-                for child in self.lateral(climber):
-                    yield from self.size_filter(maxsize=maxsize, localroot=child)
-            elif climber == self.root() or self.size(self.parent(climber)) >= maxsize:
-                yield climber
-                break
+        for root in roots:
+            for climber in self.main_path(root):
+                if self.size(climber) >= maxsize:
+                    for child in self.lateral(climber):
+                        yield from self.size_filter(maxsize=maxsize, localroot=child)
+                elif (
+                    not self.is_nonroot(climber)
+                    or self.size(self.parent(climber)) >= maxsize
+                ):
+                    yield climber
+                    break
 
     def innermost(self, nodes, localroot=None):
         """Yield innermost nodes of the given nodes."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
+            roots = self.roots()
+        else:
+            roots = (localroot,)
         filter = list(nodes)
         countdown = {n: len(self.children(n)) for n in self.subtree(localroot)}
 
@@ -775,7 +818,7 @@ class Forest:
         def _yield_or_propagate(node):
             if node in filter:
                 yield node
-            elif node != localroot:
+            elif node not in roots:
                 parent = self.parent(node)
                 countdown[parent] -= 1
                 if countdown[parent] == 0:
@@ -788,30 +831,33 @@ class Forest:
         """Yield outermost nodes of the given nodes."""
         # defaults:
         if localroot is None:
-            localroot = self.root()
+            roots = self.roots()
+        else:
+            roots = (localroot,)
         filter = list(nodes)
 
         # Recursive "top-down" search via children:
         def _yield_or_branch(node):
             if node in filter:
                 yield node
-            elif self.has_children(node):
+            else:
                 for child in self.children(node):
                     yield from _yield_or_branch(child)
 
-        yield from _yield_or_branch(localroot)
+        for root in roots:
+            yield from _yield_or_branch(root)
 
     # Initialization algorithms:
 
     def _find_full(self):
         """Compute attribute: self._full."""
 
-        def fullnodes():
-            yield self.root()
+        def _fullnodes():
+            yield from self.roots()
             yield from self.lateral_descendants()
 
         self._full = {
-            node: full for full in fullnodes() for node in self.main_path(full)
+            node: full for full in _fullnodes() for node in self.main_path(full)
         }
 
 

--- a/peakoscope/utilities.py
+++ b/peakoscope/utilities.py
@@ -51,6 +51,7 @@ False
 """
 
 
+from itertools import chain
 from peakoscope.errors import PeakyBlunder
 
 
@@ -64,6 +65,18 @@ def pairwise(iterable):
     for b in it:
         yield a, b
         a = b
+
+
+def sample_iterator(iterable, samplesize=2):
+    """Return a sample and an iterator."""
+    iterator = iter(iterable)
+    sample = []
+    countdown = samplesize
+    for element in iterator:
+        sample.append(element)
+        if (countdown := countdown - 1) == 0:
+            break
+    return sample, chain(sample, iterator)
 
 
 # Classes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,14 +21,14 @@ X2, Y2 = peakoscope.example_2()
 discrete_randomwalk = peakoscope.data.randomwalk(
     start=123,
     steps=peakoscope.data.discrete_steps(
-        length=49, moves=[3, 1, 0, -1, -3], randomseed=None
+        length=59, moves=[3, 1, 0, -1, -3], randomseed=None
     ),
 )
 
 
 continuous_randomwalk = peakoscope.data.randomwalk(
     start=123.0,
-    steps=peakoscope.data.continuous_steps(length=49, moves=[3, -3], randomseed=None),
+    steps=peakoscope.data.continuous_steps(length=59, moves=[3, -3], randomseed=None),
 )
 
 
@@ -42,6 +42,8 @@ zigzag_randomwalk = peakoscope.data.randomwalk(
 
 
 # Pathological data sets:
+
+
 empty = []
 singleton = [123]
 flat = [123, 123]
@@ -53,19 +55,34 @@ nosignal = [123.0, 123.0, 123.0, 123.0, 123.0, 123.0, 123.0, 123.0, 123.0]
 # Test data:
 
 
-@pytest.fixture(
-    params=[
-        discrete_randomwalk,
-        continuous_randomwalk,
-        zigzag_randomwalk,
-        Y1,
-        Y2,
-        flat,
-        up,
-        down,
-        nosignal,
-    ]
-)
+datasets = [
+    empty,
+    singleton,
+    flat,
+    up,
+    down,
+    nosignal,
+    Y1,
+    Y2,
+    discrete_randomwalk,
+    continuous_randomwalk,
+    zigzag_randomwalk,
+]
+
+
+@pytest.fixture(params=datasets)
+def all_data(request):
+    data = request.param
+    return data
+
+
+@pytest.fixture(params=[singleton, flat, nosignal])
+def flat_data(request):
+    data = request.param
+    return data
+
+
+@pytest.fixture(params=datasets[2:])
 def data0(request):
     data = request.param
     return data
@@ -77,13 +94,25 @@ def zigzag_data(request):
     return data
 
 
-@pytest.fixture(params=[discrete_randomwalk, continuous_randomwalk, zigzag_randomwalk])
+@pytest.fixture(
+    params=[
+        discrete_randomwalk[:40],
+        continuous_randomwalk[:40],
+        zigzag_randomwalk[:40],
+    ]
+)
 def data1(request):
     data = request.param
     return data
 
 
-@pytest.fixture(params=[discrete_randomwalk, continuous_randomwalk, zigzag_randomwalk])
+@pytest.fixture(
+    params=[
+        discrete_randomwalk[40:],
+        continuous_randomwalk[40:],
+        zigzag_randomwalk[40:],
+    ]
+)
 def data2(request):
     data = request.param
     return data

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev6"
+    assert peakoscope.__version__ == "1.2.0.dev7"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev1"
+    assert peakoscope.__version__ == "1.2.0.dev2"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev10"
+    assert peakoscope.__version__ == "1.2.0.dev11"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev11"
+    assert peakoscope.__version__ == "1.2.0.dev12"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev2"
+    assert peakoscope.__version__ == "1.2.0.dev3"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.1.0"
+    assert peakoscope.__version__ == "1.2.0.dev1"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev9"
+    assert peakoscope.__version__ == "1.2.0.dev10"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev5"
+    assert peakoscope.__version__ == "1.2.0.dev6"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev3"
+    assert peakoscope.__version__ == "1.2.0.dev4"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev4"
+    assert peakoscope.__version__ == "1.2.0.dev5"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev12"
+    assert peakoscope.__version__ == "1.2.0"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev7"
+    assert peakoscope.__version__ == "1.2.0.dev8"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,4 +10,4 @@ import peakoscope
 
 
 def test_version():
-    assert peakoscope.__version__ == "1.2.0.dev8"
+    assert peakoscope.__version__ == "1.2.0.dev9"

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -56,14 +56,14 @@ def assert_main_children_keep_argext_lateral_children_move_away(tree):
 
 
 def assert_dict_of_dicts_of_same_length(tree):
-    """Assert tree length equals dict sizes."""
+    """Assert tree or forest length equals dict sizes."""
     assert all(
         len(tree) == len(d) for d in tree.as_dict_of_dicts().values() if type(d) == dict
     )
 
 
 def assert_parents_and_children_belong_to_tree(tree):
-    """Assert that hyper parent and children methods produce tree nodes.
+    """Assert that hyper parent and children methods produce tree or forest nodes.
 
     See also Proposition 4.
     """
@@ -74,7 +74,7 @@ def assert_parents_and_children_belong_to_tree(tree):
 
 
 def assert_grid_nodes_belong_to_tree(tree):
-    """Assert that hyper size_filter produces tree nodes.
+    """Assert that hyper size_filter produces tree or forest nodes.
 
     See also Proposition 7.
     """
@@ -82,7 +82,7 @@ def assert_grid_nodes_belong_to_tree(tree):
 
 
 def assert_leafs_belong_to_tree(tree):
-    """Assert that hyper leaf_nodes produces tree nodes."""
+    """Assert that hyper leaf_nodes produces tree or forest nodes."""
     assert all(x in tree for x in tree.leaf_nodes())
 
 
@@ -265,7 +265,7 @@ def test_zero_element(all_data):
 
 
 def test_non_linear_tree(zigzag_data, is_forest):
-    """Assert that zigzag data gives tree without linear nodes."""
+    """Assert that zigzag data gives tree or forest without linear nodes."""
     assert len(list(peakoscope.tree(zigzag_data, forest=is_forest).linear_nodes())) == 0
 
 
@@ -327,9 +327,9 @@ def test_tree_set_nodes(data1):
 
 def test_forest_set_nodes(data1):
     """Test the method Forest.set_nodes."""
-    # create tree with nodes of type Scope:
+    # create forest with nodes of type Scope:
     scope_tree = peakoscope.tree(data1, forest=True)
-    # create tree with nodes of type Scope6:
+    # create forest with nodes of type Scope6:
     scope6_tree = Forest.from_peaks(map(lambda t: Scope6(*t), find_peaks(data1)))
     # lists of nodes are NOT equal:
     assert list(scope_tree) != list(scope6_tree)

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -9,20 +9,14 @@ import pytest
 from operator import attrgetter
 import peakoscope
 import peakoscope.testing as testing
-from peakoscope import Tree, Forest, HyperTree, Scope, Scope6, find_peaks
+from peakoscope import Tree, Forest, HyperTree, HyperForest, Scope, Scope6, find_peaks
 
 
-# test Tree and Forest objects (one-dimensional):
+# Assert functions:
 
 
-@pytest.fixture(params=[(True, True), (False, True), (True, False), (False, False)])
-def tree(data0, request):
-    valleys, forest = request.param
-    return peakoscope.tree(data0, valleys=valleys, forest=forest)
-
-
-def test_tree(tree):
-    """Test that Tree (or Forest) objects pass peakoscope.testing."""
+def assert_all_assertions(tree):
+    """Assert all tree assertions in peakoscope.testing."""
     testing.assert_iteration_produces_members(tree)
     testing.assert_leafs_have_no_children_and_root_has_no_parent(tree)
     testing.assert_parent_and_children_are_inverse_of_each_other(tree)
@@ -48,99 +42,55 @@ def test_tree(tree):
     testing.assert_size_filter_equals_definition(tree)
 
 
-def test_tree_nodes_are_nested_scopes(tree):
+def assert_tree_nodes_are_nested_scopes(tree):
     """Assert nesting of regions: parent > child and root > full > tip."""
     assert all(x < tree.parent(x) for x in tree if tree.is_nonroot(x))
     assert all(y < x for x in tree for y in tree.children(x))
     assert all(tree.tip(x) <= x <= tree.full(x) <= tree.root() for x in tree)
 
 
-def test_main_children_keep_argext_lateral_children_move_away(tree):
+def assert_main_children_keep_argext_lateral_children_move_away(tree):
     """Assert that main/lateral child has same/different argext as parent."""
     assert all(x.argext == tree.parent(x).argext for x in tree.main_descendants())
     assert all(x.argext != tree.parent(x).argext for x in tree.lateral_descendants())
 
 
-def test_dict_of_dicts_of_same_length(tree):
+def assert_dict_of_dicts_of_same_length(tree):
     """Assert tree length equals dict sizes."""
     assert all(
         len(tree) == len(d) for d in tree.as_dict_of_dicts().values() if type(d) == dict
     )
 
 
-# test HyperTree objects (pairs of 1D trees):
-
-
-@pytest.fixture(params=[True, False])
-def pair_of_trees(data1, data2, request):
-    valleys = request.param
-    return (
-        peakoscope.tree(data1, valleys=valleys),
-        peakoscope.tree(data2, valleys=valleys),
-    )
-
-
-def test_hypertree(pair_of_trees):
-    """Test that HyperTree objects pass peakoscope.testing."""
-    t1, t2 = pair_of_trees
-    testing.assert_iteration_produces_members(t1 @ t2)
-    testing.assert_leafs_have_no_children_and_root_has_no_parent(t1 @ t2)
-    testing.assert_parent_and_children_are_inverse_of_each_other(t1 @ t2)
-    testing.assert_level_is_length_of_root_path(t1 @ t2)
-    testing.assert_root_is_outermost_and_leafs_are_innermost(t1 @ t2)
-    # tree partitions:
-    testing.assert_tree_consists_of_children_and_root(t1 @ t2)
-    testing.assert_tree_consists_of_leafs_and_linears_and_branches(t1 @ t2)
-    testing.assert_tree_consists_of_full_nodes_and_main_descendants(t1 @ t2)
-    testing.assert_full_nodes_consists_of_lateral_descendants_plus_root(t1 @ t2)
-    testing.assert_children_consist_of_main_child_plus_lateral_children(t1 @ t2)
-    testing.assert_tree_consists_of_main_paths(t1 @ t2)
-    # tip and full:
-    testing.assert_being_tip_is_having_no_main_child(t1 @ t2)
-    testing.assert_main_child_keeps_tip_and_lateral_changes_tip(t1 @ t2)
-    testing.assert_main_path_shares_tip_and_full(t1 @ t2)
-    testing.assert_root_is_full_and_leafs_are_tips(t1 @ t2)
-    # node size:
-    testing.assert_parent_size_is_strictly_greater(t1 @ t2)
-    testing.assert_if_local_extremum_then_leaf(t1 @ t2)
-    # size filter:
-    testing.assert_size_filter_equals_outermost_of_below_maxsize(t1 @ t2)
-    testing.assert_size_filter_equals_definition(t1 @ t2)
-
-
-def test_parents_and_children_belong_to_tree(pair_of_trees):
-    """Assert that HyperTree parent and children methods produces tree nodes.
+def assert_parents_and_children_belong_to_tree(tree):
+    """Assert that hyper parent and children methods produce tree nodes.
 
     See also Proposition 4.
     """
-    tree = HyperTree(*pair_of_trees)
     # parent in tree:
     assert all(tree.parent(x) in tree for x in tree if tree.is_nonroot(x))
     # children in tree:
     assert all(x in tree for y in tree for x in tree.children(y))
 
 
-def test_grid_nodes_belong_to_tree(pair_of_trees):
-    """Assert that method HyperTree.size_filter produces tree nodes.
+def assert_grid_nodes_belong_to_tree(tree):
+    """Assert that hyper size_filter produces tree nodes.
 
     See also Proposition 7.
     """
-    tree = HyperTree(*pair_of_trees)
     assert all(x in tree for x in tree.size_filter())
 
 
-def test_leafs_belong_to_tree(pair_of_trees):
-    """Assert that method HyperTree.leaf_nodes produces tree nodes."""
-    tree = HyperTree(*pair_of_trees)
+def assert_leafs_belong_to_tree(tree):
+    """Assert that hyper leaf_nodes produces tree nodes."""
     assert all(x in tree for x in tree.leaf_nodes())
 
 
-def test_parent_size_equals_minimum(pair_of_trees):
-    """Assert that HyperTree parent size is the smallest of L/R parent sizes.
+def assert_parent_size_equals_minimum(tree):
+    """Assert that hyper parent size is the smallest of L/R parent sizes.
 
     See also Proposition 2.
     """
-    tree = HyperTree(*pair_of_trees)
     assert all(
         tree.size(tree.parent((a, b)))
         == min(tree.L.size(tree.L.parent(a)), tree.R.size(tree.R.parent(b)))
@@ -149,14 +99,104 @@ def test_parent_size_equals_minimum(pair_of_trees):
     )
 
 
+# parameter fixtures:
+
+
 @pytest.fixture(params=[0.0, 0.01, 0.2, 0.6, 2.0])
 def fraction(request):
     return request.param
 
 
-def test_recursion_equals_cartesian_product(pair_of_trees, monkeypatch, fraction):
+@pytest.fixture(params=[False, True])
+def are_valleys(request):
+    return request.param
+
+
+@pytest.fixture(params=[False, True])
+def is_forest(request):
+    return request.param
+
+
+def prune1(f):
+    """Strip input forest of roots and some leafs."""
+    return f - f.roots() - set(n for n in f.leaf_nodes() if f.full(n) != f.tip(n))
+
+
+@pytest.fixture(params=[lambda f: f, prune1])
+def prune(request):
+    return request.param
+
+
+# test Tree objects (one-dimensional):
+
+
+@pytest.fixture()
+def tree(data0, are_valleys):
+    return peakoscope.tree(data0, valleys=are_valleys)
+
+
+def test_tree(tree):
+    """Test Tree objects."""
+    assert_all_assertions(tree)
+    assert_tree_nodes_are_nested_scopes(tree)
+    assert_main_children_keep_argext_lateral_children_move_away(tree)
+    assert_dict_of_dicts_of_same_length(tree)
+
+
+# test Forest objects (one-dimensional):
+
+
+@pytest.fixture()
+def forest(all_data, are_valleys, prune):
+    return prune(peakoscope.tree(all_data, valleys=are_valleys, forest=True))
+
+
+def test_forest(forest):
+    """Test Forest objects."""
+    assert_all_assertions(forest)
+    assert_main_children_keep_argext_lateral_children_move_away(forest)
+    assert_dict_of_dicts_of_same_length(forest)
+
+
+def test_tree_nodes_are_nested_scopes(forest):
+    """Assert nesting of regions: parent > child and root > full > tip."""
+    tree = forest
+    assert all(x < tree.parent(x) for x in tree if tree.is_nonroot(x))
+    assert all(y < x for x in tree for y in tree.children(x))
+    assert all(tree.tip(x) <= x <= tree.full(x) <= tree.root(x) for x in tree)
+
+
+def test_forest_operations(forest):
+    """Test set operations on forests."""
+    assert repr(forest) == repr(Forest(are_valleys=forest.are_valleys) | forest)
+    assert repr(forest & forest.leaf_nodes()) == repr(
+        forest - forest.linear_nodes() - forest.branch_nodes()
+    )
+
+
+# test HyperTree objects (pairs of 1D trees):
+
+
+@pytest.fixture()
+def hypertree(data1, data2, are_valleys):
+    return HyperTree(
+        peakoscope.tree(data1, valleys=are_valleys),
+        peakoscope.tree(data2, valleys=are_valleys),
+    )
+
+
+def test_hypertree(hypertree):
+    """Test HyperTree objects."""
+    assert_all_assertions(hypertree)
+    assert_parents_and_children_belong_to_tree(hypertree)
+    assert_grid_nodes_belong_to_tree(hypertree)
+    assert_leafs_belong_to_tree(hypertree)
+    assert_parent_size_equals_minimum(hypertree)
+
+
+def test_recursion_equals_cartesian_product(hypertree, monkeypatch, fraction):
     """Assert that two algorithms are equivalent."""
-    tree = HyperTree(*pair_of_trees)
+    tree = hypertree
     rootsize = tree.size(tree.root())
     # output of size_filter:
     by_cartesian_product = set(tree.size_filter(maxsize=fraction * rootsize))
@@ -168,51 +208,130 @@ def test_recursion_equals_cartesian_product(pair_of_trees, monkeypatch, fraction
     assert by_recursion == by_cartesian_product
 
 
+# test HyperForest objects (pairs of 1D forests):
+
+
+@pytest.fixture()
+def hyperforest(data1, data2, are_valleys, prune):
+    return HyperForest(
+        peakoscope.tree(data1, valleys=are_valleys, forest=True),
+        prune(peakoscope.tree(data2, valleys=are_valleys, forest=True)),
+    )
+
+
+def test_hyperforest(hyperforest):
+    """Test HyperForest objects."""
+    assert_all_assertions(hyperforest)
+    assert_parents_and_children_belong_to_tree(hyperforest)
+    assert_grid_nodes_belong_to_tree(hyperforest)
+    assert_leafs_belong_to_tree(hyperforest)
+    assert_parent_size_equals_minimum(hyperforest)
+
+
+def test_recursion_equals_cartesian_product2(hyperforest, monkeypatch, fraction):
+    """Assert that two algorithms are equivalent."""
+    tree = hyperforest
+    rootsize = max((tree.size(root) for root in tree.roots()), default=0)
+    # output of size_filter:
+    by_cartesian_product = set(tree.size_filter(maxsize=fraction * rootsize))
+    # now change the algorithm behind size_filter:
+    monkeypatch.setattr(HyperForest, "size_filter", Forest.size_filter)
+    # output of size_filter reloaded:
+    by_recursion = set(tree.size_filter(maxsize=fraction * rootsize))
+    # output are equal as sets of nodes:
+    assert by_recursion == by_cartesian_product
+
+
 # special tests with special data:
 
 
-def test_non_linear_tree(zigzag_data):
+def test_identity_element(all_data, flat_data):
+    """Test that a Forest of flat data is an identity element."""
+    forest = peakoscope.tree(all_data, forest=True)
+    unity = peakoscope.tree(flat_data, forest=True)
+    assert all(
+        f == fu[0] == uf[1] for f, fu, uf in zip(forest, forest @ unity, unity @ forest)
+    )
+    assert all(
+        forest.size(f) == (forest @ unity).size(fu) == (unity @ forest).size(uf)
+        for f, fu, uf in zip(forest, forest @ unity, unity @ forest)
+    )
+
+
+def test_zero_element(all_data):
+    """Test that an empty Forest is a zero element."""
+    forest = peakoscope.tree(all_data, forest=True)
+    zero = Forest()
+    len(zero) == len(forest @ zero) == len(zero @ forest) == 0
+
+
+def test_non_linear_tree(zigzag_data, is_forest):
     """Assert that zigzag data gives tree without linear nodes."""
-    assert len(list(peakoscope.tree(zigzag_data).linear_nodes())) == 0
+    assert len(list(peakoscope.tree(zigzag_data, forest=is_forest).linear_nodes())) == 0
 
 
-def test_eval_repr(data1):
+def test_str_forest(data1):
+    """Assert that forest str is a concatenation of tree str."""
+    forest1 = prune1(peakoscope.tree(data1, forest=True))
+    assert str(forest1) == "\n".join(
+        str(Tree.from_peaks(forest1.subtree(root), presorted=False))
+        for root in forest1.roots()
+    )
+
+
+def test_eval_repr_tree(data1):
     """Assert that tree repr is readable by eval."""
     Scope.default_data = data1
     tree = peakoscope.tree(data1)
-    forest = peakoscope.tree(data1, forest=True)
     # Tree:
     assert repr(tree) == repr(eval(repr(tree)))
-    # Forest:
-    assert repr(forest) == repr(eval(repr(forest)))
     # HyperTree:
     assert repr(tree @ tree) == repr(eval(repr(tree @ tree)))
     assert repr(tree @ tree @ tree) == repr(eval(repr(tree @ tree @ tree)))
     Scope.default_data = None
 
 
-def test_children_are_sorted_by_extremum(data1):
+def test_eval_repr_forest(all_data, prune):
+    """Assert that forest repr is readable by eval."""
+    Scope.default_data = all_data
+    forest = prune(peakoscope.tree(all_data, forest=True))
+    # Forest:
+    assert repr(forest) == repr(eval(repr(forest)))
+    # HyperForest:
+    assert repr(forest @ forest) == repr(eval(repr(forest @ forest)))
+    Scope.default_data = None
+
+
+def test_children_are_sorted_by_extremum(data1, is_forest, are_valleys):
     """Assert peak children sorted by max, valley children sorted by min."""
-    peaks = peakoscope.tree(data1)
-    valleys = peakoscope.tree(data1, valleys=True)
+    tree = peakoscope.tree(data1, valleys=are_valleys, forest=is_forest)
     assert all(
-        list(peaks.children(x))
-        == sorted(peaks.children(x), key=attrgetter("extremum"), reverse=True)
-        for x in peaks
-    )
-    assert all(
-        list(valleys.children(x))
-        == sorted(valleys.children(x), key=attrgetter("extremum"), reverse=False)
-        for x in valleys
+        list(tree.children(x))
+        == sorted(tree.children(x), key=attrgetter("extremum"), reverse=not are_valleys)
+        for x in tree
     )
 
 
-def test_changing_the_node_type(data1):
+def test_tree_set_nodes(data1):
     """Test the method Tree.set_nodes."""
     # create tree with nodes of type Scope:
     scope_tree = peakoscope.tree(data1)
     # create tree with nodes of type Scope6:
     scope6_tree = Tree.from_peaks(map(lambda t: Scope6(*t), find_peaks(data1)))
+    # lists of nodes are NOT equal:
+    assert list(scope_tree) != list(scope6_tree)
+    # change from Scope6 to Scope:
+    scope6_tree.set_nodes({s6: Scope.from_attrs(s6, data1) for s6 in scope6_tree})
+    # now lists of nodes are equal:
+    assert list(scope_tree) == list(scope6_tree)
+
+
+def test_forest_set_nodes(data1):
+    """Test the method Forest.set_nodes."""
+    # create tree with nodes of type Scope:
+    scope_tree = peakoscope.tree(data1, forest=True)
+    # create tree with nodes of type Scope6:
+    scope6_tree = Forest.from_peaks(map(lambda t: Scope6(*t), find_peaks(data1)))
     # lists of nodes are NOT equal:
     assert list(scope_tree) != list(scope6_tree)
     # change from Scope6 to Scope:

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -119,7 +119,7 @@ def is_forest(request):
 
 def prune1(f):
     """Strip input forest of roots and some leafs."""
-    return f - f.roots() - set(n for n in f.leaf_nodes() if f.full(n) != f.tip(n))
+    return f - f.roots() - (set(f.leaf_nodes()) - set(f.full_nodes()))
 
 
 @pytest.fixture(params=[lambda f: f, prune1])
@@ -224,7 +224,6 @@ def test_hyperforest(hyperforest):
     assert_all_assertions(hyperforest)
     assert_parents_and_children_belong_to_tree(hyperforest)
     assert_grid_nodes_belong_to_tree(hyperforest)
-    assert_leafs_belong_to_tree(hyperforest)
     assert_parent_size_equals_minimum(hyperforest)
 
 
@@ -262,7 +261,7 @@ def test_zero_element(all_data):
     """Test that an empty Forest is a zero element."""
     forest = peakoscope.tree(all_data, forest=True)
     zero = Forest()
-    len(zero) == len(forest @ zero) == len(zero @ forest) == 0
+    assert len(zero) == len(forest @ zero) == len(zero @ forest) == 0
 
 
 def test_non_linear_tree(zigzag_data, is_forest):

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -9,20 +9,20 @@ import pytest
 from operator import attrgetter
 import peakoscope
 import peakoscope.testing as testing
-from peakoscope import Tree, HyperTree, Scope, Scope6, find_peaks
+from peakoscope import Tree, Forest, HyperTree, Scope, Scope6, find_peaks
 
 
-# test Tree objects (one-dimensional):
+# test Tree and Forest objects (one-dimensional):
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[(True, True), (False, True), (True, False), (False, False)])
 def tree(data0, request):
-    valleys = request.param
-    return peakoscope.tree(data0, valleys=valleys)
+    valleys, forest = request.param
+    return peakoscope.tree(data0, valleys=valleys, forest=forest)
 
 
 def test_tree(tree):
-    """Test that Tree objects pass peakoscope.testing."""
+    """Test that Tree (or Forest) objects pass peakoscope.testing."""
     testing.assert_iteration_produces_members(tree)
     testing.assert_leafs_have_no_children_and_root_has_no_parent(tree)
     testing.assert_parent_and_children_are_inverse_of_each_other(tree)
@@ -180,8 +180,11 @@ def test_eval_repr(data1):
     """Assert that tree repr is readable by eval."""
     Scope.default_data = data1
     tree = peakoscope.tree(data1)
+    forest = peakoscope.tree(data1, forest=True)
     # Tree:
     assert repr(tree) == repr(eval(repr(tree)))
+    # Forest:
+    assert repr(forest) == repr(eval(repr(forest)))
     # HyperTree:
     assert repr(tree @ tree) == repr(eval(repr(tree @ tree)))
     assert repr(tree @ tree @ tree) == repr(eval(repr(tree @ tree @ tree)))


### PR DESCRIPTION
## Goal:
- Add set operations between trees (union, intersection, etc).
- PyPI release v1.2.0.

## Wanted features:
- Pruning and grafting of trees, for example, removing a subtree and adding other subtrees.
- Deleting any tree node. If the root is deleted, a tree may split into two or more trees. If a tip node is deleted, its parent becomes the tip node (but may still have lateral children).
- A Forest class for multiple trees. Forest implements all set operations (union, intersection, difference, etc.).
- The empty Forest is possible (a Forest minus itself).
- Generalize to a HyperForest class (`f @ g`).
- A Forest `str` is a concatenation of tree `str`.

## Solution:
- The new classes Forest and HyperForest are not containers of trees but containers of tree nodes, possibly with multiple root nodes.
- The Forest class (not HyperForest) defines set operations between a Forest object and an iterable of nodes, making it easy to create a Forest of any combination of nodes: Union `f | g`, intersection `f & g`, difference `f - g` and symmetric difference `f ^ g`.
- Set operations work between forests of peaks or forest of valleys (don’t mix peaks and valleys). This means that a forest must know which of the two it is. This is implemented with a boolean instance variable: `are_valleys`.
- The Forest is implemented with data structures (dicts) for the whole Forest, rather than data structures for each tree. The presence of nodes in the Forest is implemented as presence in the data structure, rather than a boolean mask.
- Forest and Tree have mostly the same API, as well as HyperForest and HyperTree. For example, all have a `root()` and a `roots()` method. 
- Forest and HyperForest are not derived from Tree and HyperTree, that will be deprecated.
- New iteration tool `sample_iterator()` is used to handle numeric sequences with zero or one element (it was at least two before).
- Empty data,`Forest()`and `Forest(are_valleys=True)` produce forests with no nodes. These empty forests act as zero elements under `@`.
- Data with a constant value produce single-node forests that act as identity elements under `@`.
- Test coverage:
```

---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                 Stmts   Miss  Cover   Missing
------------------------------------------------------------------
peakoscope/__init__.py                  13      0   100%
peakoscope/__main__.py                  21     21     0%   6-91
peakoscope/data.py                      23      1    96%   98
peakoscope/errors.py                     3      0   100%
peakoscope/formats.py                   51     42    18%   34-35, 39-43, 48-57, 62-86, 101-120
peakoscope/interface_matplotlib.py      86     71    17%   34-46, 64, 79, 91, 127-159, 163-169, 173-185, 189-200, 204-216, 220-234
peakoscope/interface_pandas.py          61     42    31%   60-82, 86-87, 91-104, 108-111, 121, 130, 139, 147-149, 153, 163, 167, 176
peakoscope/interface_polars.py          60     41    32%   60-82, 86-87, 91-94, 105-108, 118, 132, 144, 153-159, 174, 184, 188, 197
peakoscope/peaks.py                    149     13    91%   117, 158, 162, 201, 206-208, 213, 218-220, 273, 314
peakoscope/testing.py                   64      1    98%   41
peakoscope/trees.py                    733     52    93%   150-155, 328, 419, 441-445, 529-535, 593-594, 685, 730, 850-851, 880, 900, 910-914, 926, 945, 1101-1102, 1128, 1132, 1136, 1140, 1144, 1148, 1304, 1316-1317, 1323, 1327, 1331, 1335, 1339, 1343, 1347, 1351, 1355, 1359
peakoscope/utilities.py                 44      3    93%   100, 104, 113
------------------------------------------------------------------
TOTAL                                 1308    287    78%

```